### PR TITLE
Simplify sort rules to remove complex logic

### DIFF
--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -93,10 +93,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.kohsuke</groupId>
-                <artifactId>pgp-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
@@ -24,8 +24,7 @@ public class KuduRules {
 
   public static final KuduFilterRule FILTER = new KuduFilterRule(RelFactories.LOGICAL_BUILDER);
   public static final KuduProjectRule PROJECT = new KuduProjectRule(RelFactories.LOGICAL_BUILDER);
-  public static final RelOptRule FILTER_SORT = KuduSortRule.FILTER_SORT_RULE;
-  public static final RelOptRule SORT = KuduSortRule.SIMPLE_SORT_RULE;
+  public static final RelOptRule SORT = KuduSortRule.INSTANCE;
   public static final KuduLimitRule LIMIT = new KuduLimitRule();
   public static final RelOptRule SORT_OVER_JOIN_TRANSPOSE = new SortInnerJoinTranspose(RelFactories.LOGICAL_BUILDER);
   public static final KuduNestedJoinRule NESTED_JOIN = new KuduNestedJoinRule.KuduNestedOverFilter(
@@ -37,8 +36,8 @@ public class KuduRules {
   public static final KuduNestedJoinRule NESTED_JOIN_OVER_LIMIT_SORT_FILTER = new KuduNestedJoinRule.KuduNestedOverLimitAndSortAndFilter(
       RelFactories.LOGICAL_BUILDER);
 
-  public static List<RelOptRule> RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
-      SORT_OVER_JOIN_TRANSPOSE, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
-      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN, NESTED_JOIN_OVER_SORT,
-      NESTED_JOIN_OVER_LIMIT, NESTED_JOIN_OVER_LIMIT_SORT_FILTER, KuduToEnumerableConverter.INSTANCE);
+  public static List<RelOptRule> RULES = Arrays.asList(FILTER, PROJECT, SORT, LIMIT, SORT_OVER_JOIN_TRANSPOSE,
+      NESTED_JOIN, NESTED_JOIN_OVER_SORT, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
+      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN_OVER_LIMIT,
+      NESTED_JOIN_OVER_LIMIT_SORT_FILTER, KuduToEnumerableConverter.INSTANCE);
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -88,8 +88,12 @@ public class KuduSortRule extends RelOptRule {
       if (sortField.getFieldIndex() >= openedTable.getSchema().getPrimaryKeyColumnCount()) {
         return false;
       }
-      if (sortField.getFieldIndex() != pkColumnIndex) {
 
+      // Iterate through all the primary key columns below this one and assert that
+      // all of them have
+      // strict filter on them. If one of them does don not apply the rule by
+      // returning FALSE
+      while (sortField.getFieldIndex() > pkColumnIndex) {
         if (predicates == null) {
           predicates = mq.getAllPredicates(original);
           if (predicates == null) {

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -99,7 +99,7 @@ public class KuduSortRule extends RelOptRule {
           }
         }
 
-        final Boolean nonPkIsFiltered = isColumnStrictlyFiltered(predicates, mq, original, sortField.getFieldIndex());
+        final Boolean nonPkIsFiltered = isColumnStrictlyFiltered(predicates, sortField.getFieldIndex());
         if (!nonPkIsFiltered) {
           return false;
         }
@@ -118,7 +118,7 @@ public class KuduSortRule extends RelOptRule {
               return false;
             }
           }
-          final boolean primaryKeyIncluded = isColumnStrictlyFiltered(predicates, mq, original, pkColumnIndex);
+          final boolean primaryKeyIncluded = isColumnStrictlyFiltered(predicates, pkColumnIndex);
           if (!primaryKeyIncluded) {
             return false;
           } else {
@@ -131,8 +131,7 @@ public class KuduSortRule extends RelOptRule {
     return true;
   }
 
-  private boolean isColumnStrictlyFiltered(final RelOptPredicateList predicates, final RelMetadataQuery mq,
-      final RelNode original, final int column) {
+  private boolean isColumnStrictlyFiltered(final RelOptPredicateList predicates, final int column) {
     final KuduFilterVisitor visitor = new KuduFilterVisitor(column);
     return predicates.pulledUpPredicates.stream().anyMatch(rexNode -> {
       final Boolean matched = rexNode.accept(visitor);

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
@@ -117,15 +117,14 @@ public abstract class KuduSortedAggregationRule extends KuduSortRule {
         .canonize(RelCollations.permute(originalSort.getCollation(), remappingOrdinals));
     final RelTraitSet traitSet = originalSort.getTraitSet().plus(newCollation).plus(Convention.NONE);
 
-    // Check the new trait set to see if we can apply the sort against this.
-    if (!canApply(traitSet, query, query.calciteKuduTable.getKuduTable(), Optional.of(filter))) {
-      return;
-    }
-
     final KuduSortRel newSort = new KuduSortRel(project.getCluster(), traitSet.replace(KuduRelNode.CONVENTION),
         convert(project, project.getTraitSet().replace(RelCollations.EMPTY)), newCollation,
         originalLimit.isPresent() ? originalLimit.get().offset : originalSort.offset,
         originalLimit.isPresent() ? originalLimit.get().fetch : originalSort.fetch, true);
+    // Check the new trait set to see if we can apply the sort against this.
+    if (!canApply(newSort)) {
+      return;
+    }
 
     // Copy in the new collation because! this new rel is now coming out Sorted.
     final RelNode newkuduToEnumerableRel = kuduToEnumerableRel

--- a/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
@@ -32,8 +32,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.Date;
@@ -52,7 +50,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public final class DescendingSortedOnDatetimeIT {
-  private static final Logger logger = LoggerFactory.getLogger(JDBCQueryIT.class);
 
   private static String FIRST_SID = "SM1234857";
   private static String SECOND_SID = "SM123485789";
@@ -261,7 +258,7 @@ public final class DescendingSortedOnDatetimeIT {
           + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567])\n"
           + "      KuduQuery(table=[[kudu, Test.Events]])\n";
       String expectedPlan = String.format(expectedPlanFormat, ACCOUNT_SID);
-      assertEquals("Unexpected plan ", expectedPlan, plan);
+      assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
       rs = conn.createStatement().executeQuery(firstBatchSql);
 
       assertTrue(rs.next());
@@ -394,6 +391,53 @@ public final class DescendingSortedOnDatetimeIT {
       validateRow(rs, 1546390800000L, DescendingSortedOnDatetimeIT.FIRST_SID);
       assertTrue(rs.next());
       validateRow(rs, 1546304400000L, DescendingSortedOnDatetimeIT.THIRD_SID);
+    }
+  }
+
+  @Test
+  public void testSortOnSid() throws Exception {
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      // Because the first two columns of the primary key are filtered to exact values
+      // this should
+      // pass.
+      String firstBatchSqlFormat = "SELECT * FROM kudu.\"Test.Events\" "
+          + "WHERE account_sid = '%s' and event_date = TIMESTAMP'2019-01-01 00:00:00' " + "ORDER BY sid asc";
+
+      String firstBatchSql = String.format(firstBatchSqlFormat, ACCOUNT_SID);
+
+      // verify plan
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
+      String plan = SqlUtil.getExplainPlan(rs);
+      String expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(sort0=[$2], dir0=[ASC], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567, event_date EQUAL 1546300800000000])\n"
+          + "      KuduQuery(table=[[kudu, Test.Events]])\n";
+      String expectedPlan = String.format(expectedPlanFormat, ACCOUNT_SID);
+      assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
+      rs = conn.createStatement().executeQuery(firstBatchSql);
+    }
+  }
+
+  @Test
+  public void testSortOnSidWithDateRange() throws Exception {
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      // Because the event_date doesn't have an exact filter, we should not apply kudu
+      // sort
+      // This test demostrates the need for the while loop in the Sort Rule.
+      String firstBatchSqlFormat = "SELECT * FROM kudu.\"Test.Events\" "
+          + "WHERE account_sid = '%s' and event_date <= TIMESTAMP'2019-01-01 00:00:00' " + "ORDER BY sid asc";
+
+      String firstBatchSql = String.format(firstBatchSqlFormat, ACCOUNT_SID);
+
+      // verify plan
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
+      String plan = SqlUtil.getExplainPlan(rs);
+      String expectedPlanFormat = "EnumerableSort(sort0=[$2], dir0=[ASC])\n" + "  KuduToEnumerableRel\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567, event_date LESS_EQUAL 1546300800000000])\n"
+          + "      KuduQuery(table=[[kudu, Test.Events]])\n";
+      String expectedPlan = String.format(expectedPlanFormat, ACCOUNT_SID);
+      assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
+      rs = conn.createStatement().executeQuery(firstBatchSql);
     }
   }
 }

--- a/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
@@ -230,8 +230,8 @@ public final class JDBCQueryIT {
           + "WHERE account_sid = '%s' ORDER BY account_sid, date_created, sid";
       String sql = String.format(sqlFormat, JDBCQueryIT.ACCOUNT_SID);
       String expectedPlan = "KuduToEnumerableRel\n"
-          + "  KuduProjectRel(SID=[$2], ACCOUNT_SID=[$0], DATE_CREATED=[$1])\n"
-          + "    KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[ASC], dir2=[ASC], groupBySorted=[false])\n"
+          + "  KuduSortRel(sort0=[$1], sort1=[$2], sort2=[$0], dir0=[ASC], dir1=[ASC], dir2=[ASC], groupBySorted=[false])\n"
+          + "    KuduProjectRel(SID=[$2], ACCOUNT_SID=[$0], DATE_CREATED=[$1])\n"
           + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567])\n"
           + "        KuduQuery(table=[[kudu, ReportCenter.DeliveredMessages]])\n";
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.kohsuke</groupId>
+                        <artifactId>pgp-maven-plugin</artifactId>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -337,10 +341,6 @@
 		<configuration>
 	          <skipTests>${skipTests}</skipTests>
         	</configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.kohsuke</groupId>
-                <artifactId>pgp-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Summary:
These rules feel very tortured. This simplifies the operand a lot and
preps it for moving to a Converter rule.

It simplifies the operands and leverages the
`RelMetadataQuery#getAllPredicates` to surface up the filter
conditions. This should allow it to be more generic and applicable.

TODO:
Need to come back around to the sorted aggregation rule and adjust it
to use the new sort aggregation in kudu enumerable rules


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
