### PR TITLE
Revert Sort Simplification

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
@@ -24,7 +24,8 @@ public class KuduRules {
 
   public static final KuduFilterRule FILTER = new KuduFilterRule(RelFactories.LOGICAL_BUILDER);
   public static final KuduProjectRule PROJECT = new KuduProjectRule(RelFactories.LOGICAL_BUILDER);
-  public static final RelOptRule SORT = KuduSortRule.INSTANCE;
+  public static final RelOptRule FILTER_SORT = KuduSortRule.FILTER_SORT_RULE;
+  public static final RelOptRule SORT = KuduSortRule.SIMPLE_SORT_RULE;
   public static final KuduLimitRule LIMIT = new KuduLimitRule();
   public static final RelOptRule SORT_OVER_JOIN_TRANSPOSE = new SortInnerJoinTranspose(RelFactories.LOGICAL_BUILDER);
   public static final KuduNestedJoinRule NESTED_JOIN = new KuduNestedJoinRule.KuduNestedOverFilter(
@@ -36,8 +37,8 @@ public class KuduRules {
   public static final KuduNestedJoinRule NESTED_JOIN_OVER_LIMIT_SORT_FILTER = new KuduNestedJoinRule.KuduNestedOverLimitAndSortAndFilter(
       RelFactories.LOGICAL_BUILDER);
 
-  public static List<RelOptRule> RULES = Arrays.asList(FILTER, PROJECT, SORT, LIMIT, SORT_OVER_JOIN_TRANSPOSE,
-      NESTED_JOIN, NESTED_JOIN_OVER_SORT, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
-      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN_OVER_LIMIT,
-      NESTED_JOIN_OVER_LIMIT_SORT_FILTER, KuduToEnumerableConverter.INSTANCE);
+  public static List<RelOptRule> RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
+      SORT_OVER_JOIN_TRANSPOSE, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
+      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN, NESTED_JOIN_OVER_SORT,
+      NESTED_JOIN_OVER_LIMIT, NESTED_JOIN_OVER_LIMIT_SORT_FILTER, KuduToEnumerableConverter.INSTANCE);
 }

--- a/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
@@ -230,8 +230,8 @@ public final class JDBCQueryIT {
           + "WHERE account_sid = '%s' ORDER BY account_sid, date_created, sid";
       String sql = String.format(sqlFormat, JDBCQueryIT.ACCOUNT_SID);
       String expectedPlan = "KuduToEnumerableRel\n"
-          + "  KuduSortRel(sort0=[$1], sort1=[$2], sort2=[$0], dir0=[ASC], dir1=[ASC], dir2=[ASC], groupBySorted=[false])\n"
-          + "    KuduProjectRel(SID=[$2], ACCOUNT_SID=[$0], DATE_CREATED=[$1])\n"
+          + "  KuduProjectRel(SID=[$2], ACCOUNT_SID=[$0], DATE_CREATED=[$1])\n"
+          + "    KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[ASC], dir2=[ASC], groupBySorted=[false])\n"
           + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567])\n"
           + "        KuduQuery(table=[[kudu, ReportCenter.DeliveredMessages]])\n";
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);


### PR DESCRIPTION
Summary:
As noted in the last comment in this PR:
https://github.com/twilio/calcite-kudu/pull/2#issuecomment-754976144

The rule is failing to properly handle a Sort Over a Projection. When
Sort is over a Projection, the `sortField.getFieldIndex()` reflects
the field's position in the Projection and the code assumed it
reflected the field's position in the Kudu table.

This reverts commit bd9f9055a074afae0d940deaae8edaaad7c375b6, reversing
changes made to 0b44ba05eceaa238b94fcde6132c82244ed7ee7d.

This includes a new Test to show the issue and prevent future regressions.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
