### PR TITLE
Fix regression on Nested Join

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 import com.twilio.kudu.sql.KuduQuery;
 import com.twilio.kudu.sql.KuduRelNode;
 import com.twilio.kudu.sql.rel.KuduSortRel;
+import com.twilio.kudu.sql.rel.KuduToEnumerableRel;
+
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
@@ -45,9 +47,11 @@ import org.apache.kudu.client.KuduTable;
  */
 public abstract class KuduSortRule extends RelOptRule {
 
-  private static final RelOptRuleOperand SIMPLE_OPERAND = operand(KuduQuery.class, none());
+  private static final RelOptRuleOperand SIMPLE_OPERAND = operand(KuduToEnumerableRel.class,
+      some(operand(KuduQuery.class, none())));
 
-  private static final RelOptRuleOperand FILTER_OPERAND = operand(Filter.class, some(operand(KuduQuery.class, none())));
+  private static final RelOptRuleOperand FILTER_OPERAND = operand(KuduToEnumerableRel.class,
+      some(operand(Filter.class, some(operand(KuduQuery.class, none())))));
 
   public static final RelOptRule SIMPLE_SORT_RULE = new KuduSortWithoutFilter(RelFactories.LOGICAL_BUILDER);
   public static final RelOptRule FILTER_SORT_RULE = new KuduSortWithFilter(RelFactories.LOGICAL_BUILDER);
@@ -133,7 +137,7 @@ public abstract class KuduSortRule extends RelOptRule {
 
     @Override
     public void onMatch(final RelOptRuleCall call) {
-      final KuduQuery query = (KuduQuery) call.getRelList().get(1);
+      final KuduQuery query = (KuduQuery) call.getRelList().get(2);
       final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
       final Sort originalSort = (Sort) call.getRelList().get(0);
 
@@ -154,8 +158,8 @@ public abstract class KuduSortRule extends RelOptRule {
 
     @Override
     public void onMatch(final RelOptRuleCall call) {
-      final KuduQuery query = (KuduQuery) call.getRelList().get(2);
-      final Filter filter = (Filter) call.getRelList().get(1);
+      final KuduQuery query = (KuduQuery) call.getRelList().get(3);
+      final Filter filter = (Filter) call.getRelList().get(2);
       final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
       final Sort originalSort = (Sort) call.getRelList().get(0);
 

--- a/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
@@ -358,12 +358,12 @@ public final class DescendingSortedOnDatetimeIT {
       // verify plan
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
-      String expectedPlanFormat = "KuduToEnumerableRel\n"
-          + "  KuduSortRel(sort0=[$1], dir0=[DESC], fetch=[1], groupBySorted=[false])\n"
-          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567, event_date LESS_EQUAL 1546387200000000])\n"
-          + "      KuduQuery(table=[[kudu, Test.Events]])\n";
+      String expectedPlanFormat = "KuduToEnumerableRel\n" + "  KuduLimitRel(limit=[1])\n"
+          + "    KuduSortRel(sort0=[$1], dir0=[DESC], groupBySorted=[false])\n"
+          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567, event_date LESS_EQUAL 1546387200000000])\n"
+          + "        KuduQuery(table=[[kudu, Test.Events]])\n";
       String expectedPlan = String.format(expectedPlanFormat, ACCOUNT_SID);
-      assertEquals("Unexpected plan ", expectedPlan, plan);
+      assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
       rs = conn.createStatement().executeQuery(firstBatchSql);
 
       assertTrue(rs.next());


### PR DESCRIPTION
Summary:
Our internal integration tests identified a regression with
NestedLoopJoin. This Rel needs to be reworked to match
`org.apache.calcite.adapter.enumerable.EnumerableBatchNestedJoin`
instead of this current one. To avoid having to rework it completely
now, this commit fixes that regression and kicks the can down the road



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
