### PR TITLE
Build a Caching Nested Join implementation

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduMethod.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduMethod.java
@@ -20,8 +20,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.calcite.linq4j.function.EqualityComparer;
 import org.apache.calcite.linq4j.function.Function1;
 import org.apache.calcite.linq4j.function.Predicate1;
+import org.apache.calcite.linq4j.function.Predicate2;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.core.Join;
 
@@ -34,7 +36,8 @@ public enum KuduMethod {
       boolean.class),
   KUDU_MUTATE_TUPLES_METHOD(CalciteKuduTable.KuduQueryable.class, "mutateTuples", List.class, List.class),
   KUDU_MUTATE_ROW_METHOD(CalciteKuduTable.KuduQueryable.class, "mutateRow", List.class, List.class),
-  NESTED_JOIN_PREDICATES(KuduEnumerable.class, "nestedJoinPredicates", Join.class);
+  NESTED_JOIN_PREDICATES(KuduEnumerable.class, "nestedJoinPredicates", Join.class, EqualityComparer.class,
+      Predicate2.class);
 
   public final Method method;
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduRowCache.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduRowCache.java
@@ -1,0 +1,143 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.calcite.linq4j.function.EqualityComparer;
+import org.apache.calcite.linq4j.function.Predicate2;
+
+/**
+ * {@code KuduRowCache} contains a fixed size cache for the right hand side of a
+ * {@link com.twilio.kudu.sql.rel.KuduNestedJoin}
+ */
+public class KuduRowCache {
+  private final LinkedList<CacheHit> cacheList;
+  private final EqualityComparer<Object> comparer;
+  private final int cacheSize;
+
+  /**
+   * Create a cache with the provided {@link EqualityComparer} for the cache and a
+   * fixed size
+   *
+   * @param comparer  captures how to compare rows on the right hand side as equal
+   *                  or not
+   * @param cacheSize maximum size of the cache.
+   */
+  public KuduRowCache(final EqualityComparer<Object> comparer, final int cacheSize) {
+    this.comparer = comparer;
+    this.cacheList = new LinkedList<>();
+    this.cacheSize = cacheSize;
+  }
+
+  /**
+   * Search the cache for records that match the rows on the from the left table
+   *
+   * @param batchFromLeftTable rows fetched from the Left table to match
+   * @param joinCondition      a function that compares a row from the left and a
+   *                           row in the cache to see if it satisifies the join
+   *                           condition
+   *
+   * @return {@link SearchResult} that contains both the hits and the misses.
+   */
+  public SearchResult cacheSearch(final List<Object> batchFromLeftTable,
+      final Predicate2<Object, Object> joinCondition) {
+    // @TODO: size estimation? We know it won't be larger than batchFromRight
+    final ArrayList<Object> cacheMisses = new ArrayList<>();
+    final ArrayList<Integer> indicesInCache = new ArrayList<>();
+
+    final HashSet<CacheHit> hits = new HashSet<>();
+    for (Object leftRow : batchFromLeftTable) {
+      boolean foundInCache = false;
+      for (int j = 0; j < cacheList.size(); j++) {
+        final CacheHit cachedRightRow = cacheList.get(j);
+        if (joinCondition.apply(leftRow, cachedRightRow.rowValue)) {
+          // Keep track of cache shuffling for this row.
+          if (hits.add(cachedRightRow)) {
+            indicesInCache.add(j);
+          }
+          foundInCache = true;
+          break;
+        }
+      }
+      if (!foundInCache) {
+        cacheMisses.add(leftRow);
+      }
+    }
+
+    // @TODO: reshuffle the cache list and push the hits to the front.
+
+    if (hits.isEmpty()) {
+      return new SearchResult(Collections.emptyList(), cacheMisses);
+    } else {
+      return new SearchResult(hits.stream().map(h -> h.rowValue).collect(Collectors.toList()), cacheMisses);
+    }
+  }
+
+  /**
+   * Add the right row into the cache and ensure the cache doesn't grow to large
+   *
+   * @param rightRow the row from the right hand side of the join.
+   */
+  public void addToCache(final Object rightRow) {
+    cacheList.push(new CacheHit(rightRow));
+    if (cacheList.size() > cacheSize) {
+      cacheList.pollLast();
+    }
+  }
+
+  private class CacheHit {
+    final Object rowValue;
+
+    CacheHit(Object hit) {
+      this.rowValue = hit;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (o instanceof CacheHit) {
+        return comparer.equal(rowValue, ((CacheHit) o).rowValue);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return comparer.hashCode(rowValue);
+    }
+  }
+
+  public class SearchResult {
+    /**
+     * Rows from the in memory cache that match rows on the left.
+     */
+    List<Object> cachedRightRows;
+
+    /**
+     * Rows from the left table that do not match anything in the cache;
+     */
+    List<Object> cacheMisses;
+
+    SearchResult(final List<Object> cachedRightRows, final List<Object> cacheMisses) {
+      this.cachedRightRows = cachedRightRows;
+      this.cacheMisses = cacheMisses;
+    }
+  }
+}

--- a/adapter/src/main/java/com/twilio/kudu/sql/NestedJoinFactory.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/NestedJoinFactory.java
@@ -1,0 +1,140 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.linq4j.function.EqualityComparer;
+import org.apache.calcite.linq4j.function.Function1;
+import org.apache.calcite.linq4j.function.Predicate2;
+import org.apache.kudu.client.AsyncKuduScanner;
+
+/**
+ * {@code NestedJoinFactory} is an implementation of {@link Function1} that
+ * returns an {@link Enumerable} for the Right hand side of a nested join.
+ * <p>
+ * This implementation uses a cache to hold objects from the scan to prevent
+ * going creating {@link AsyncKuduScanner} for repeated rows
+ */
+public final class NestedJoinFactory implements Function1<List<Object>, Enumerable<Object>> {
+
+  private final KuduRowCache rowCache;
+
+  private final Predicate2<Object, Object> joinCondition;
+
+  private final List<TranslationPredicate> rowTranslators;
+
+  private final KuduEnumerable rootEnumerable;
+
+  public NestedJoinFactory(final Predicate2<Object, Object> joinCondition, final EqualityComparer<Object> compareUtil,
+      final List<TranslationPredicate> rowTranslators, final KuduEnumerable rootEnumerable) {
+    this.joinCondition = joinCondition;
+    this.rowCache = new KuduRowCache(compareUtil, 1000);
+    this.rowTranslators = rowTranslators;
+    this.rootEnumerable = rootEnumerable;
+  }
+
+  @Override
+  public Enumerable<Object> apply(final List<Object> batchFromLeftTable) {
+    final KuduRowCache.SearchResult cacheResult = rowCache.cacheSearch(batchFromLeftTable, joinCondition);
+
+    // Indicates it can all be served from cache;
+    final Enumerator<Object> cacheScan = Linq4j.iterableEnumerator(cacheResult.cachedRightRows);
+    if (cacheResult.cacheMisses.isEmpty()) {
+      return new AbstractEnumerable<Object>() {
+        @Override
+        public Enumerator<Object> enumerator() {
+          return cacheScan;
+
+        }
+      };
+    }
+    final Set<List<CalciteKuduPredicate>> pushDownPredicates = cacheResult.cacheMisses.stream()
+        .map(s -> rowTranslators.stream().map(t -> t.toPredicate((Object[]) s)).collect(Collectors.toList()))
+        .collect(Collectors.toSet());
+
+    final KuduEnumerable clone = rootEnumerable.clone(new LinkedList<>(pushDownPredicates));
+
+    final Enumerable<Object> rightScan = new AbstractEnumerable<Object>() {
+      @Override
+      public Enumerator<Object> enumerator() {
+        return new CacheAndScanEnumerator(cacheScan, clone.enumerator(), rowCache);
+      }
+    };
+
+    return rightScan;
+  }
+
+  class CacheAndScanEnumerator implements Enumerator<Object> {
+
+    final Enumerator<Object> hits;
+    final Enumerator<Object> scan;
+    final KuduRowCache rowCache;
+    boolean cacheFirst = true;
+
+    CacheAndScanEnumerator(final Enumerator<Object> hits, final Enumerator<Object> scan, final KuduRowCache rowCache) {
+      this.scan = scan;
+      this.hits = hits;
+      this.rowCache = rowCache;
+    }
+
+    @Override
+    public Object current() {
+      if (cacheFirst) {
+        return hits.current();
+      } else {
+        return scan.current();
+      }
+    }
+
+    @Override
+    public boolean moveNext() {
+      if (cacheFirst) {
+        cacheFirst = hits.moveNext();
+      }
+      if (cacheFirst) {
+        return cacheFirst;
+      } else {
+        final boolean scanSuccessful = scan.moveNext();
+        if (scanSuccessful) {
+          rowCache.addToCache(scan.current());
+        }
+        return scanSuccessful;
+      }
+    }
+
+    @Override
+    public void reset() {
+      hits.reset();
+      scan.reset();
+
+    }
+
+    @Override
+    public void close() {
+      hits.close();
+      scan.close();
+
+    }
+
+  }
+}

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduNestedJoin.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduNestedJoin.java
@@ -140,7 +140,8 @@ public class KuduNestedJoin extends Join implements EnumerableRel {
     builder.append(Expressions.call(BuiltInMethod.CORRELATE_BATCH_JOIN.method,
         Expressions.constant(toLinq4jJoinType(joinType)), leftExpression,
         Expressions.call(Expressions.convert_(rightExpression, KuduEnumerable.class),
-            KuduMethod.NESTED_JOIN_PREDICATES.method, implementor.stash(this, Join.class)),
+            KuduMethod.NESTED_JOIN_PREDICATES.method, implementor.stash(this, Join.class),
+            rightResult.physType.comparer(), predicate),
         selector, predicate, Expressions.constant(batchSize)));
     return implementor.result(physType, builder.toBlock());
   }

--- a/adapter/src/test/java/com/twilio/kudu/sql/KuduRowCacheTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/KuduRowCacheTest.java
@@ -1,0 +1,112 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.twilio.kudu.sql.KuduRowCache.SearchResult;
+
+import org.apache.calcite.linq4j.function.EqualityComparer;
+import org.apache.calcite.linq4j.function.Predicate2;
+import org.junit.Test;
+
+public class KuduRowCacheTest {
+
+  private EqualityComparer<Object> cacheEqualCheck = new EqualityComparer<Object>() {
+    @Override
+    public boolean equal(Object v1, Object v2) {
+      return v1.equals(v2);
+    }
+
+    @Override
+    public int hashCode(Object t) {
+      return t.hashCode();
+    }
+  };
+
+  private Predicate2<Object, Object> joinMatches = (v0, v1) -> v0.equals(v1);
+
+  @Test
+  public void emptyCache() {
+
+    final List<Object> leftBatch = Arrays.asList("account1", "account2");
+    final KuduRowCache cache = new KuduRowCache(cacheEqualCheck, 10);
+    final SearchResult cacheResult = cache.cacheSearch(leftBatch, joinMatches);
+
+    assertTrue(String.format("Cache hits should be empty: %s", cacheResult.cachedRightRows),
+        cacheResult.cachedRightRows.isEmpty());
+    assertEquals(String.format("Cache misses should match the search: %s", cacheResult.cacheMisses), leftBatch,
+        cacheResult.cacheMisses);
+  }
+
+  @Test
+  public void singleMatch() {
+
+    final List<Object> leftBatch = Arrays.asList("account1", "account2", "account3", "account4", "account5");
+    final KuduRowCache cache = new KuduRowCache(cacheEqualCheck, 10);
+    cache.addToCache("account3");
+    cache.addToCache("account4");
+    cache.addToCache("account2");
+    cache.addToCache("account5");
+    cache.addToCache("account6");
+    cache.addToCache("account10");
+
+    final SearchResult cacheResult = cache.cacheSearch(leftBatch, joinMatches);
+
+    assertEquals(
+        String.format("Cache result should have a cache matches for account2 - 5: %s", cacheResult.cachedRightRows),
+        Arrays.asList("account5", "account2", "account4", "account3"), cacheResult.cachedRightRows);
+    assertEquals(String.format("Cache misses contain only account1", cacheResult.cacheMisses),
+        Arrays.asList("account1"), cacheResult.cacheMisses);
+  }
+
+  @Test
+  public void noMatchingJoinCondition() {
+
+    final List<Object> leftBatch = Arrays.asList("account1", "account2");
+    final KuduRowCache cache = new KuduRowCache(cacheEqualCheck, 10);
+    cache.addToCache("account1235");
+    cache.addToCache("account12389");
+    cache.addToCache("account2");
+
+    final SearchResult cacheResult = cache.cacheSearch(leftBatch, Predicate2.FALSE);
+
+    assertTrue(String.format("Cache hits should be empty: %s", cacheResult.cachedRightRows),
+        cacheResult.cachedRightRows.isEmpty());
+    assertEquals(String.format("Cache misses should match the search: %s", cacheResult.cacheMisses), leftBatch,
+        cacheResult.cacheMisses);
+  }
+
+  @Test
+  public void cachedRowEvicted() {
+
+    final List<Object> leftBatch = Arrays.asList("account1", "account2");
+    final KuduRowCache cache = new KuduRowCache(cacheEqualCheck, 2);
+    cache.addToCache("account2");
+    cache.addToCache("account1235");
+    cache.addToCache("account12389");
+
+    final SearchResult cacheResult = cache.cacheSearch(leftBatch, joinMatches);
+
+    assertTrue(String.format("Cache hits should be empty: %s", cacheResult.cachedRightRows),
+        cacheResult.cachedRightRows.isEmpty());
+    assertEquals(String.format("Cache misses should match the search: %s", cacheResult.cacheMisses), leftBatch,
+        cacheResult.cacheMisses);
+  }
+}


### PR DESCRIPTION
Summary:
Today, nested joins can be very slow creating the same Scanners for
the right table. It is common, for instance, to fetch the same right
rows after each batch from the left.

This attempts to cache some results from the Right scan that match the
left side.

The `KuduRowCache` maintains a `LinkedList` of cached rows and it uses
a `EqualityComparer` to reduce duplicates and to power comparisons.

### KuduRowCache
This object is created once per query. It contains a `LinkedList` of `CacheHit`, an `EqualityComparer` that is created at compilation time and a fix size. It provides two methods:
1. `cacheSearch` - scan the `LinkedList` for any `CacheHit` that matches the `joinCondition` and remove it from the `TranslatedPredicate` of the `KuduNestedJoin`
2. `addToCache` - called whenever a row is pulled from the right table. This inserts the result into the cache

Today, this cache is naive, it is just insertion order and doesn't do an LRU implementation.

### NestedJoinFactory
This class is an implementation of `Function1` that used by [`correlateBatchJoin`](https://github.com/apache/calcite/blob/calcite-1.26.0/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java#L1609-L1634) that takes as input a `List` of rows from the Left table and returns an `Enumerable` that can match those.  This class creates the `KuduRowCache` and uses it for each iteration. 

When all the Left rows are in the cache, it returns an enumerator over the cache results only. When there are some misses, it creates an Enumerator that first returns the misses and then returns the results from a Kudu scan *over only the misses*. 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
