### PR TITLE
Caching Nested Join implementation

### DIFF
--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/adapter/src/main/java/com/twilio/kudu/sql/CloneableEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CloneableEnumerable.java
@@ -1,0 +1,35 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql;
+
+import java.util.List;
+
+import org.apache.calcite.linq4j.Enumerable;
+
+/**
+ * An {@link Enumerable} that can be cloned with additional conjunctions.
+ */
+public interface CloneableEnumerable<T> extends Enumerable<T> {
+  /**
+   * Clone this enumerable by merging the {@link CalciteKuduPredicate} into
+   * existing set.
+   *
+   * @param conjunctions the additional predicates that need to be conjoined to
+   *                     the query.
+   *
+   * @return another {@code CloneableEnumerable} with the additional conjunctions
+   */
+  public CloneableEnumerable<T> clone(final List<List<CalciteKuduPredicate>> conjunctions);
+}

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -70,7 +70,7 @@ import org.apache.kudu.client.KuduScannerUtil;
  * {@link org.apache.kudu.client.AsyncKuduScanner} will return rows sorted by
  * primary key.
  */
-public final class KuduEnumerable extends AbstractEnumerable<Object> {
+public final class KuduEnumerable extends AbstractEnumerable<Object> implements CloneableEnumerable<Object> {
   private static final Logger logger = LoggerFactory.getLogger(KuduEnumerable.class);
 
   private final AtomicBoolean scansShouldStop;
@@ -527,7 +527,8 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> {
     return scanners;
   }
 
-  public KuduEnumerable clone(final List<List<CalciteKuduPredicate>> conjunctions) {
+  @Override
+  public CloneableEnumerable<Object> clone(final List<List<CalciteKuduPredicate>> conjunctions) {
     // The result of the merge can be an empty list. That means we are scanning
     // everything.
     // @TODO: can we generate unique predicates? What happens when it contains the
@@ -556,7 +557,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> {
     }
     final List<TranslationPredicate> rowTranslators = joinNode.getCondition()
         .accept(new TranslationPredicate.ConditionTranslationVisitor(joinNode.getLeft().getRowType().getFieldCount(),
-            rightSideProjection, this.getTableSchema()));
+            rightSideProjection));
     return new NestedJoinFactory(1000, rowTranslators, this);
   }
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/NestedJoinFactory.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/NestedJoinFactory.java
@@ -1,0 +1,194 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.function.Function1;
+import org.apache.kudu.client.AsyncKuduScanner;
+
+/**
+ * {@code NestedJoinFactory} is an implementation of {@link Function1} that
+ * returns an {@link Enumerable} for the Right hand side of a nested join.
+ * <p>
+ * This implementation uses a cache to hold objects from the scan to prevent
+ * going creating {@link AsyncKuduScanner} for repeated rows
+ */
+public final class NestedJoinFactory implements Function1<List<Object>, Enumerable<Object>> {
+
+  private final ResultCache resultCache;
+  private final KuduEnumerable rootEnumerable;
+  private final List<TranslationPredicate> rowTranslators;
+
+  /**
+   * Create a Factory that produces {@link Enumerable} that can cache results from
+   * previous calls
+   *
+   * @param capacity       size of the RPC cache
+   * @param rowTranslators bindable predicates that depend on the row from the
+   *                       left side of the join
+   * @param rootEnumerable base enumerable that will be
+   *                       {@link KuduEnumerable#clone(List)}
+   */
+  public NestedJoinFactory(final int capacity, final List<TranslationPredicate> rowTranslators,
+      final KuduEnumerable rootEnumerable) {
+    this.resultCache = new ResultCache(capacity);
+    this.rowTranslators = rowTranslators;
+    this.rootEnumerable = rootEnumerable;
+  }
+
+  @Override
+  public Enumerable<Object> apply(final List<Object> batchFromLeftTable) {
+    final List<Enumerator<Object>> enumerators = batchFromLeftTable.stream()
+        .map(rowFromLeft -> rowTranslators.stream().map(t -> t.toPredicate((Object[]) rowFromLeft))
+            .collect(Collectors.toList()))
+        .map(predicates -> resultCache.compute(predicates, (existingPredicates, existingEnumerator) -> {
+          if (existingEnumerator == null) {
+            return new CachingEnumerator(
+                rootEnumerable.clone(Collections.singletonList(existingPredicates)).enumerator());
+          }
+          existingEnumerator.reset();
+          return existingEnumerator;
+        })).collect(Collectors.toList());
+
+    return new AbstractEnumerable<Object>() {
+      @Override
+      public Enumerator<Object> enumerator() {
+        return new EnumeratorOfEnumerators(enumerators);
+      }
+    };
+  }
+
+  private final class EnumeratorOfEnumerators implements Enumerator<Object> {
+    final List<Enumerator<Object>> enumerators;
+    private int currentEnumerator = 0;
+
+    EnumeratorOfEnumerators(final List<Enumerator<Object>> enumerators) {
+      this.enumerators = enumerators;
+    }
+
+    @Override
+    public Object current() {
+      return enumerators.get(currentEnumerator).current();
+    }
+
+    @Override
+    public boolean moveNext() {
+      final boolean currentSuccess = enumerators.get(currentEnumerator).moveNext();
+      if (currentSuccess) {
+        return true;
+      }
+      while (++currentEnumerator < enumerators.size()) {
+        final boolean nextSuccess = enumerators.get(currentEnumerator).moveNext();
+        if (nextSuccess) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public void reset() {
+      enumerators.forEach(e -> e.reset());
+      currentEnumerator = 0;
+    }
+
+    @Override
+    public void close() {
+      enumerators.forEach(e -> e.close());
+    }
+  }
+
+  private final class CachingEnumerator implements Enumerator<Object> {
+    private final Enumerator<Object> actualEnumerator;
+    private final List<Object> cachedValues = new ArrayList<>();
+    private boolean doneScan = false;
+    private boolean started = false;
+    private int cursor = -1;
+    private Object current = null;
+
+    CachingEnumerator(final Enumerator<Object> actualEnumerator) {
+      this.actualEnumerator = actualEnumerator;
+    }
+
+    @Override
+    public Object current() {
+      return current;
+    }
+
+    @Override
+    public boolean moveNext() {
+      started = true;
+      if (doneScan) {
+        final boolean moved = ++cursor < cachedValues.size();
+        if (moved) {
+          current = cachedValues.get(cursor);
+          return true;
+        }
+        return false;
+      } else {
+        final boolean scanResult = actualEnumerator.moveNext();
+        if (!scanResult) {
+          doneScan = true;
+          actualEnumerator.close();
+        } else {
+          current = actualEnumerator.current();
+          cachedValues.add(current);
+        }
+        return scanResult;
+      }
+    }
+
+    @Override
+    public void reset() {
+      if (started && !doneScan) {
+        actualEnumerator.reset();
+      }
+      cursor = -1;
+    }
+
+    @Override
+    public void close() {
+      actualEnumerator.close();
+      cursor = -1;
+    }
+  }
+
+  private final class ResultCache extends LinkedHashMap<List<CalciteKuduPredicate>, CachingEnumerator> {
+    /**
+     * Default Serialization id for the {@link LinkedHashMap} interface
+     */
+    private static final long serialVersionUID = 1L;
+    private int capacity;
+
+    ResultCache(final int capacity) {
+      this.capacity = capacity;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<List<CalciteKuduPredicate>, CachingEnumerator> eldest) {
+      return size() > capacity;
+    }
+  }
+}

--- a/adapter/src/main/java/com/twilio/kudu/sql/NestedJoinFactory.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/NestedJoinFactory.java
@@ -17,7 +17,6 @@ package com.twilio.kudu.sql;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,7 +37,7 @@ import org.apache.kudu.client.AsyncKuduScanner;
 public final class NestedJoinFactory implements Function1<List<Object>, Enumerable<Object>> {
 
   private final ResultCache resultCache;
-  private final KuduEnumerable rootEnumerable;
+  private final CloneableEnumerable<Object> rootEnumerable;
   private final List<TranslationPredicate> rowTranslators;
 
   /**
@@ -49,10 +48,10 @@ public final class NestedJoinFactory implements Function1<List<Object>, Enumerab
    * @param rowTranslators bindable predicates that depend on the row from the
    *                       left side of the join
    * @param rootEnumerable base enumerable that will be
-   *                       {@link KuduEnumerable#clone(List)}
+   *                       {@link CloneableEnumerable#clone(List)}
    */
   public NestedJoinFactory(final int capacity, final List<TranslationPredicate> rowTranslators,
-      final KuduEnumerable rootEnumerable) {
+      final CloneableEnumerable<Object> rootEnumerable) {
     this.resultCache = new ResultCache(capacity);
     this.rowTranslators = rowTranslators;
     this.rootEnumerable = rootEnumerable;

--- a/adapter/src/test/java/com/twilio/kudu/sql/NestedJoinCacheTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/NestedJoinCacheTest.java
@@ -1,0 +1,115 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.kudu.client.KuduPredicate.ComparisonOp;
+import org.junit.Test;
+
+public final class NestedJoinCacheTest {
+  @Test
+  public void cacheTest() {
+    final List<TranslationPredicate> joinTranslations = Collections
+        .singletonList(new TranslationPredicate(1, 0, ComparisonOp.EQUAL));
+    final CloneableEnumerable<Object> mockBaseEnumerable = mock(CloneableEnumerable.class);
+    final NestedJoinFactory joinFactory = new NestedJoinFactory(10, joinTranslations, mockBaseEnumerable);
+    final CloneableEnumerable<Object> mockEnumerableFirstRow = mock(CloneableEnumerable.class);
+    final CloneableEnumerable<Object> mockEnumerableSecondRow = mock(CloneableEnumerable.class);
+    final CloneableEnumerable<Object> mockEnumerableThirdRow = mock(CloneableEnumerable.class);
+    final List<Object> firstBatch = Arrays.asList(new Object[] { "Awesome", Integer.valueOf(1) },
+        new Object[] { "Awesome2", Integer.valueOf(2) }, new Object[] { "Awesome3", Integer.valueOf(3) });
+
+    List<List<CalciteKuduPredicate>> firstRowPredicates = Collections
+        .singletonList(Arrays.asList(new ComparisonPredicate(0, ComparisonOp.EQUAL, Integer.valueOf(1))));
+    List<List<CalciteKuduPredicate>> secondRowPredicates = Collections
+        .singletonList(Arrays.asList(new ComparisonPredicate(0, ComparisonOp.EQUAL, Integer.valueOf(2))));
+    List<List<CalciteKuduPredicate>> thirdRowPredicates = Collections
+        .singletonList(Arrays.asList(new ComparisonPredicate(0, ComparisonOp.EQUAL, Integer.valueOf(3))));
+
+    when(mockBaseEnumerable.clone(firstRowPredicates)).thenReturn(mockEnumerableFirstRow);
+    when(mockBaseEnumerable.clone(secondRowPredicates)).thenReturn(mockEnumerableSecondRow);
+    when(mockBaseEnumerable.clone(thirdRowPredicates)).thenReturn(mockEnumerableThirdRow);
+
+    when(mockEnumerableFirstRow.enumerator()).thenReturn(
+        new ListEnumerator<Object>(Collections.singletonList(new Object[] { Integer.valueOf(1), "OneRow" })));
+    when(mockEnumerableSecondRow.enumerator()).thenReturn(
+        new ListEnumerator<Object>(Collections.singletonList(new Object[] { Integer.valueOf(2), "TwoRow" })));
+    when(mockEnumerableThirdRow.enumerator()).thenReturn(
+        new ListEnumerator<Object>(Collections.singletonList(new Object[] { Integer.valueOf(3), "ThirdRow" })));
+
+    // Run the same rows through a bunch of times.
+    for (int i = 0; i < 1000; i++) {
+      final List<Object> rightHandSide = joinFactory.apply(firstBatch).toList();
+
+      assertEquals(String.format("Right hand side should return three rows it returned %d", rightHandSide.size()), 3,
+          rightHandSide.size());
+    }
+
+    // Verify that enumerator was called only once for each row.
+    Arrays.asList(mockEnumerableFirstRow, mockEnumerableSecondRow, mockEnumerableThirdRow)
+        .forEach(rowEnumerable -> verify(rowEnumerable, times(1)).enumerator());
+
+    // Test to make sure we created a clone only 3 times.
+    verify(mockBaseEnumerable, times(3)).clone(any());
+  }
+
+  class ListEnumerator<T> implements Enumerator<T> {
+
+    int i = -1;
+    final List<T> results;
+    boolean closed = false;
+
+    ListEnumerator(final List<T> results) {
+      this.results = results;
+    }
+
+    @Override
+    public T current() {
+      return results.get(i);
+    }
+
+    @Override
+    public boolean moveNext() {
+      if (closed) {
+        throw new AssertionError("Source enumerable has already been closed and it shouldn't be reopened");
+      }
+      return ++i < results.size();
+    }
+
+    @Override
+    public void reset() {
+      i = -1;
+
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <guava.version>29.0-jre</guava.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>3.7.7</mockito.version>
         <jackson.version>2.11.1</jackson.version>
         <spotless.version>2.0.1</spotless.version>
         <freemarker-version>2.3.29</freemarker-version>
@@ -186,7 +186,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <scope>test</scope>
                 <version>${mockito.version}</version>
             </dependency>


### PR DESCRIPTION
Summary:
This implements a cache between the resulting Predicates when
executing a nested loop join.

Problem:
In a Nested Loop Join, the query is sending the same RPC requests over
and over again and fetching the same results. This makes the query
perform notably slower because of all the network traffic.

Solution:
This creates a fixed size `Map<Predicates, CachedResults>` that is
local to the current nested loop join context. Each `CachedResult`
maps to a set of predicates specific to the row on the left and
therefore shouldn't return thousands or millions of results -- it is
assumed the cached results will be small but not necessarily uniform
in size.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
