### PR TITLE
Exit the Enumerable when scanner is in error state

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduEnumerable.java
@@ -105,10 +105,10 @@ public final class CalciteKuduEnumerable extends AbstractEnumerable<CalciteRow> 
             }
           }
 
-        } while (iterationNext == null || (iterationNext.type != CalciteScannerMessage.MessageType.CLOSE
-            && iterationNext.type != CalciteScannerMessage.MessageType.ROW));
+        } while (iterationNext == null
+            || (!iterationNext.isTerminal() && iterationNext.type != CalciteScannerMessage.MessageType.ROW));
 
-        if (iterationNext.type == CalciteScannerMessage.MessageType.CLOSE) {
+        if (iterationNext.isTerminal()) {
           logger.info("No more results in queue, exiting");
           finished = true;
           return false;

--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteScannerMessage.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteScannerMessage.java
@@ -107,4 +107,13 @@ public final class CalciteScannerMessage<T> {
     this.failure = Optional.empty();
     this.callback = Optional.empty();
   }
+
+  /**
+   * Whether or not this message means the end of the scan
+   *
+   * @return true if the scanner is no longer processing rows.
+   */
+  public boolean isTerminal() {
+    return type == MessageType.CLOSE || type == MessageType.ERROR;
+  }
 }

--- a/adapter/src/test/java/com/twilio/kudu/sql/CalciteKuduEnumerableTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/CalciteKuduEnumerableTest.java
@@ -60,4 +60,18 @@ public final class CalciteKuduEnumerableTest {
     assertFalse("Should be no more rows", enumerable.moveNext());
     assertEquals("current() should still be the previous row", singleRow[0], enumerable.current().getRowData());
   }
+
+  @Test
+  public void errorResult() {
+    final LinkedBlockingQueue<CalciteScannerMessage<CalciteRow>> queue = new LinkedBlockingQueue<>(10);
+    final Enumerator<CalciteRow> enumerable = new CalciteKuduEnumerable(queue, new AtomicBoolean(false)).enumerator();
+    final Object[] singleRow = { Long.valueOf(1) };
+    queue.add(new CalciteScannerMessage<CalciteRow>(
+        new CalciteRow(rowSchema, singleRow, Arrays.asList(0), Collections.<Integer>emptyList())));
+    queue.add(new CalciteScannerMessage<CalciteRow>(new RuntimeException("Testing exit")));
+    assertTrue("Should signal there are messages", enumerable.moveNext());
+    assertEquals("Row should match", singleRow[0], enumerable.current().getRowData());
+    assertFalse("Should be no more rows", enumerable.moveNext());
+    assertEquals("current() should still be the previous row", singleRow[0], enumerable.current().getRowData());
+  }
 }


### PR DESCRIPTION
Summary:
Awhile back this code was refactored and the `ScannerCallback` stopped
sending a `CLOSE` message right after an `ERROR` message. Frankly the
original behavior was silly as well. This changes that to close the
`Enumerator` whenever the message is `ERROR` or `CLOSE`

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ X] I acknowledge that all my contributions will be made under the project's license.
