### PR TITLE
Use the deconstructed condition for filter rel

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
@@ -58,7 +58,7 @@ public class KuduFilterRule extends RelOptRule {
       }
       final RelNode converted = new KuduFilterRel(filter.getCluster(),
           filter.getTraitSet().replace(KuduRelNode.CONVENTION), convert(filter.getInput(), KuduRelNode.CONVENTION),
-          filter.getCondition(), predicates, kuduQuery.calciteKuduTable.getKuduTable().getSchema(),
+          condition, predicates, kuduQuery.calciteKuduTable.getKuduTable().getSchema(),
           !predicateParser.areAllFiltersApplied());
 
       call.transformTo(converted);


### PR DESCRIPTION
Summary:
In our service, we use `ROW` type to contain two values for our paging
design. This is not really supported by Calcite and causing
compilation errors when generating the query:

```
java.lang.RuntimeException: while resolving method 'gt[class [Ljava.lang.Object;, class
[Ljava.lang.Object;]' in class class org.apache.calcite.runtime.SqlFunctions
```

This is because the in memory filters include the original `ROW` type
instead of the expanded disjunction created by:
`RowValueExpressionConverter`

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
