### PR TITLE
Use the max Cube granularity among the cubes

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/dataloader/DataLoader.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/DataLoader.java
@@ -114,7 +114,7 @@ public class DataLoader {
    */
   private Long getMaxCubeGranularity() {
     Optional<Long> option = calciteKuduTable.getCubeTables().stream()
-        .map(t -> ((CalciteModifiableKuduTable) t).getCubeMaintainer().getFloorMod()).min(Long::compare);
+        .map(t -> ((CalciteModifiableKuduTable) t).getCubeMaintainer().getFloorMod()).max(Long::compare);
     return option.orElse(DateTimeUtils.MILLIS_PER_SECOND);
   }
 
@@ -283,7 +283,6 @@ public class DataLoader {
     long prevThreadEndTimestamp = scenarioStartTimestamp;
     long rangePerThread = (scenarioEndTimestamp - scenarioStartTimestamp) / threadPoolSize;
     long threadDelta = Math.max(rangePerThread, cubeGranularityFloorMod);
-    List<CalciteKuduTable> cubeTables = calciteKuduTable.getCubeTables();
     int numRows = numRowsOverrideOption.orElseGet(scenario::getNumRows);
     for (int t = 0; t < threadPoolSize; ++t) {
       // for each thread the start time stamp is the previous threads end timestamp


### PR DESCRIPTION
In case of mixed time granularity of cubes and using min amongst them for deciding on the number of threads, the time ranges are unique for the smallest time granularity cube but not for any cube having granularity greater than that.
Hence, rows get overwritten(upserted) in CubeMutationState from different threads for any cube bigger than the smallest granularity.
In order to keep uniqueness in thread splitting of rows to write, we need the max granularity rolled up time of a cube

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [Yes ] I acknowledge that all my contributions will be made under the project's license.
