### PR TITLE
Remove `KuduToEnumerableRel` from `KuduSortRule`s

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduNestedJoin.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduNestedJoin.java
@@ -92,25 +92,10 @@ public class KuduNestedJoin extends Join implements EnumerableRel {
 
   @Override
   public RelOptCost computeSelfCost(final RelOptPlanner planner, final RelMetadataQuery mq) {
-    final double rowCount = mq.getRowCount(this);
-
-    // We expect rightRowCount to be *at most* three records.
-    // We expect our right scan to match one row but hold out for at most 3.
-    final double leftRowCount = left.estimateRowCount(mq);
-
-    // If row on the left doesn't have an estimate, or if right's estimate is >
-    // left,
-    // return infinite. Our join algorithm will not perform well.
-    if (Double.isInfinite(leftRowCount) || Double.isInfinite(right.estimateRowCount(mq))
-        || right.estimateRowCount(mq) > left.estimateRowCount(mq)) {
-      return planner.getCostFactory().makeInfiniteCost();
-    }
-
-    /**
-     * @TODO: figure out how to make a cost that beats
-     *        {@link org.apache.calcite.adapter.enumerable.EnumerableHashJoin#computeSelfCost}
-     */
-    return planner.getCostFactory().makeTinyCost();
+    double dRows = Double.MIN_VALUE;
+    double dCpu = 0;
+    double dIo = 0;
+    return planner.getCostFactory().makeCost(dRows, dCpu, dIo);
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
@@ -28,18 +28,10 @@ public class KuduRules {
   public static final RelOptRule SORT = KuduSortRule.SIMPLE_SORT_RULE;
   public static final KuduLimitRule LIMIT = new KuduLimitRule();
   public static final RelOptRule SORT_OVER_JOIN_TRANSPOSE = new SortInnerJoinTranspose(RelFactories.LOGICAL_BUILDER);
-  public static final KuduNestedJoinRule NESTED_JOIN = new KuduNestedJoinRule.KuduNestedOverFilter(
-      RelFactories.LOGICAL_BUILDER);
-  public static final KuduNestedJoinRule NESTED_JOIN_OVER_SORT = new KuduNestedJoinRule.KuduNestedOverSortAndFilter(
-      RelFactories.LOGICAL_BUILDER);
-  public static final KuduNestedJoinRule NESTED_JOIN_OVER_LIMIT = new KuduNestedJoinRule.KuduNestedOverSortAndFilter(
-      RelFactories.LOGICAL_BUILDER);
-  public static final KuduNestedJoinRule NESTED_JOIN_OVER_LIMIT_SORT_FILTER = new KuduNestedJoinRule.KuduNestedOverLimitAndSortAndFilter(
-      RelFactories.LOGICAL_BUILDER);
+  public static final KuduNestedJoinRule NESTED_JOIN = new KuduNestedJoinRule(RelFactories.LOGICAL_BUILDER);
 
   public static List<RelOptRule> RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
       SORT_OVER_JOIN_TRANSPOSE, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
-      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN, NESTED_JOIN_OVER_SORT,
-      NESTED_JOIN_OVER_LIMIT, NESTED_JOIN_OVER_LIMIT_SORT_FILTER, KuduToEnumerableConverter.INSTANCE,
+      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN, KuduToEnumerableConverter.INSTANCE,
       KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -49,11 +49,9 @@ import org.apache.kudu.client.KuduTable;
  */
 public abstract class KuduSortRule extends RelOptRule {
 
-  private static final RelOptRuleOperand SIMPLE_OPERAND = operand(KuduToEnumerableRel.class,
-      some(operand(KuduQuery.class, none())));
+  private static final RelOptRuleOperand SIMPLE_OPERAND = operand(KuduQuery.class, none());
 
-  private static final RelOptRuleOperand FILTER_OPERAND = operand(KuduToEnumerableRel.class,
-      some(operand(Filter.class, some(operand(KuduQuery.class, none())))));
+  private static final RelOptRuleOperand FILTER_OPERAND = operand(Filter.class, some(operand(KuduQuery.class, none())));
 
   public static final RelOptRule SIMPLE_SORT_RULE = new KuduSortWithoutFilter(RelFactories.LOGICAL_BUILDER);
   public static final RelOptRule FILTER_SORT_RULE = new KuduSortWithFilter(RelFactories.LOGICAL_BUILDER);
@@ -140,7 +138,7 @@ public abstract class KuduSortRule extends RelOptRule {
 
     @Override
     public void onMatch(final RelOptRuleCall call) {
-      final KuduQuery query = (KuduQuery) call.getRelList().get(2);
+      final KuduQuery query = (KuduQuery) call.getRelList().get(1);
       final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
       final Sort originalSort = (Sort) call.getRelList().get(0);
 
@@ -161,8 +159,8 @@ public abstract class KuduSortRule extends RelOptRule {
 
     @Override
     public void onMatch(final RelOptRuleCall call) {
-      final KuduQuery query = (KuduQuery) call.getRelList().get(3);
-      final Filter filter = (Filter) call.getRelList().get(2);
+      final KuduQuery query = (KuduQuery) call.getRelList().get(2);
+      final Filter filter = (Filter) call.getRelList().get(1);
       final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
       final Sort originalSort = (Sort) call.getRelList().get(0);
 

--- a/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
@@ -358,10 +358,11 @@ public final class DescendingSortedOnDatetimeIT {
       // verify plan
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
-      String expectedPlanFormat = "KuduToEnumerableRel\n" + "  KuduLimitRel(limit=[1])\n"
-          + "    KuduSortRel(sort0=[$1], dir0=[DESC], groupBySorted=[false])\n"
-          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567, event_date LESS_EQUAL 1546387200000000])\n"
-          + "        KuduQuery(table=[[kudu, Test.Events]])\n";
+      String expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(sort0=[$1], dir0=[DESC], fetch=[1], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567, event_date LESS_EQUAL 1546387200000000])\n"
+          + "      KuduQuery(table=[[kudu, Test.Events]])\n";
+
       String expectedPlan = String.format(expectedPlanFormat, ACCOUNT_SID);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
       rs = conn.createStatement().executeQuery(firstBatchSql);

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -306,10 +306,10 @@ public class PaginationIT {
       // verify plan
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
-      String expectedPlanFormat = "KuduToEnumerableRel\n" + "  KuduLimitRel(offset=[7], limit=[6])\n"
-          + "    KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], "
-          + "dir2=[ASC], groupBySorted=[false])\n" + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL %s])\n"
-          + "        KuduQuery(table=[[kudu, %s]])\n";
+      String expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], "
+          + "dir2=[ASC], offset=[7], fetch=[6], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
       String expectedPlan = String.format(expectedPlanFormat, descending ? "DESC" : "ASC", ACCOUNT1, tableName);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
       rs = conn.createStatement().executeQuery(firstBatchSql);
@@ -360,10 +360,10 @@ public class PaginationIT {
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
 
-      String expectedPlanFormat = "KuduToEnumerableRel\n" + "  KuduLimitRel(limit=[4])\n"
-          + "    KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], groupBySorted=[false])\n"
-          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, date_initiated LESS %d])\n"
-          + "        KuduQuery(table=[[kudu, %s]])\n";
+      String expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], fetch=[4], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, date_initiated LESS %d])\n"
+          + "      KuduQuery(table=[[kudu, %s]])\n";
       String expectedPlan = String.format(expectedPlanFormat, dateInitiatedOrder, ACCOUNT1, T1 * 1000, T4 * 1000,
           tableName);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
@@ -390,13 +390,13 @@ public class PaginationIT {
           + "WHERE account_sid = '%s' AND date_initiated >= TIMESTAMP'%s' AND " + "date_initiated < TIMESTAMP'%s' "
           + "AND (date_initiated, transaction_id) > (TIMESTAMP'%s', '%s') "
           + "ORDER BY date_initiated %s, transaction_id " + "LIMIT 4";
-      expectedPlanFormat = "KuduToEnumerableRel\n" + "  KuduLimitRel(limit=[4])\n"
-          + "    KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], " + "groupBySorted=[false])\n"
-          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, "
+      expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], fetch=[4], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, "
           + "date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000, "
           + "date_initiated %s %d], ScanToken 2=[account_sid EQUAL %s, "
           + "date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000, "
-          + "date_initiated EQUAL %d, transaction_id GREATER %s])\n" + "        KuduQuery(table=[[kudu, %s]])\n";
+          + "date_initiated EQUAL %d, transaction_id GREATER %s])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
 
       // keep reading batches of rows until we have processes rows for all the
       // partitions


### PR DESCRIPTION
Summary:
To support another physical trait, the sort rule can't be pinned to
`EnumerableConvention` trait.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
