### PR TITLE
Reduce cost on every `CLOSE` message when logger is > DEBUG level

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/ScannerCallback.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/ScannerCallback.java
@@ -96,7 +96,7 @@ final public class ScannerCallback implements Callback<Deferred<Void>, RowResult
     // processed?
 
     // If the scanner can continue and we are not stopping
-    if (scanner.hasMoreRows() && !earlyExit.get() && !scansShouldStop.get() &&
+    if (scanner.hasMoreRows() && !scansShouldStop.get() && !earlyExit.get() &&
     // allow `null` as cancel flag isn't guaranteed to be set. Instead of handling
     // null
     // in constructor check it here, .get() can be costly as it is atomic.
@@ -114,7 +114,7 @@ final public class ScannerCallback implements Callback<Deferred<Void>, RowResult
       // Else -> scanner has completed, notify the consumer of rowResults
       try {
         // This blocks to ensure the query finishes.
-        logger.debug("Closing scanner: {} {} {} {}", scanner.hasMoreRows(), earlyExit.get(), scansShouldStop.get(),
+        logger.debug("Closing scanner: {} {} {} {}", scanner.hasMoreRows(), earlyExit, scansShouldStop,
             cancelFlag.get());
         rowResults.put(CLOSE_MESSAGE);
       } catch (InterruptedException threadInterrupted) {


### PR DESCRIPTION
## Why:
Looking a bit at query performance for a `null set` query I noticed
this code was calling out to the `AtomicBoolean#get()`. This uses a
votiale:
https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/invoke/VarHandle.java#L579-L606

Which can be "expensive" to reference.

## How:
If the logger is configured at `DEBUG` level, then the logger will
call `AtomicBoolean#toString()` which in turn references the
`volatile` to render the String. So this doesn't change behavior if
the logger is `DEBUG` level but does prevent the `volatile` from being
dereferenced if logger is configured for `INFO` or higher.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
