### PR TITLE
`KuduFilterRel` calculates cost based on partition pruning

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -14,7 +14,10 @@
  */
 package com.twilio.kudu.sql;
 
+import java.util.List;
+
 import com.twilio.kudu.sql.rules.KuduRules;
+
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
@@ -24,8 +27,8 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
-
-import java.util.List;
+import org.apache.kudu.client.AsyncKuduClient;
+import org.apache.kudu.client.KuduTable;
 
 /**
  * Relational expression representing a scan of a KuduTable
@@ -101,5 +104,32 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
     impl.descendingColumns = this.calciteKuduTable.getDescendingOrderedColumnIndexes();
     impl.table = this.table;
     impl.tableDataType = getRowType();
+  }
+
+  /**
+   * Return internal abstraction of the table
+   * 
+   * @return {@link CalciteKuduTable} that holds some stats for the query.
+   */
+  public CalciteKuduTable getCalciteKuduTable() {
+    return calciteKuduTable;
+  }
+
+  /**
+   * Get an {@link KuduTable} for this query.
+   * 
+   * @return {@link KuduTable} used for the query
+   */
+  public KuduTable getKuduTable() {
+    return calciteKuduTable.getKuduTable();
+  }
+
+  /**
+   * Get the connected {@link AsyncKuduClient} for the query
+   * 
+   * @return Kudu client that is connected to the active cluster.
+   */
+  public AsyncKuduClient getKuduClient() {
+    return calciteKuduTable.getClient();
   }
 }


### PR DESCRIPTION
Why:
To improve the costing metrics of different plans, the `KuduFilterRel`
should cost itself based on the number of partitions out of the total
number of partitions. This calculation has to be cheap and hopefully
done once

How:
The `KuduFilterRule` now pulls out the `KuduClient` and uses it to
make a `ScanTokenBuilder` for the table without predicates and makes a
`ScanTokenBuilder` for the table with the predicates. These two sizes
allow the `KuduFilterRel` to calculate the percentage of partitions
removed. This is used to reduce the cost of the plan based on that
metric.



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
