### PR TITLE
Choose first UNIXTIME column as timestamp column

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/dataloader/DataLoader.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/DataLoader.java
@@ -79,15 +79,9 @@ public class DataLoader {
         .orElseThrow(() -> new RuntimeException("Table not found " + scenario.getTableName()));
     this.url = url;
 
-    // we assume the first UNIXTIME_MICROS column is the timestamp column
-    String timestampColumnName = null;
-    final Schema tableSchema = calciteKuduTable.getKuduTable().getSchema();
-    for (int i = 0; i < calciteKuduTable.getKuduTable().getSchema().getColumnCount(); i++) {
-      if (tableSchema.getColumnByIndex(i).getType() == Type.UNIXTIME_MICROS) {
-        timestampColumnName = tableSchema.getColumnByIndex(i).getName();
-        break;
-      }
-    }
+    // we assume there is one UNIXTIME_MICROS column in a table
+    String timestampColumnName = calciteKuduTable.getKuduTable().getSchema()
+        .getColumnByIndex(calciteKuduTable.getTimestampColumnIndex()).getName();
     UniformLongValueGenerator timestampGenerator = (UniformLongValueGenerator) scenario.getColumnNameToValueGenerator()
         .get(timestampColumnName);
     // initialize minValue and maxValue if the generator is a TimestampGenerator


### PR DESCRIPTION
Some use cases can have timestamp column which is not the second column. 
In such cases, we want to assume the first column of type UNIXTIME_MICROS to be the timestamp field. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [YES] I acknowledge that all my contributions will be made under the project's license.
