### PR TITLE
Handle possible `null` value from condition visitor

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
@@ -87,7 +87,7 @@ public class KuduNestedJoinRule extends RelOptRule {
     final boolean containsActorSid = join.getRight().getRowType().getFieldList().stream()
         .anyMatch(fl -> fl.getName().equalsIgnoreCase("actor_sid"));
 
-    return isValid && containsActorSid;
+    return isValid != null && isValid && containsActorSid;
   }
 
   @Override


### PR DESCRIPTION
## Why:
When the condition is just `TRUE` this visitor will return with a
`null` value instead of a `Boolean`.

## How:
When `isValid` is `null` treat it just like if it was `false` and do
not attempt to apply this rule.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
