### PR TITLE
Add USE_KUDU_NESTED_JOIN hint

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -15,6 +15,7 @@
 package com.twilio.kudu.sql;
 
 import com.twilio.kudu.sql.rules.KuduRules;
+import org.apache.calcite.adapter.enumerable.EnumerableRules;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
@@ -80,7 +81,7 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
 
     // After removing the Join Commute Rule, Merge Join is chosen over Hash Join,
     // negating the work down to push the KuduSortRel into the large table.
-    planner.removeRule(org.apache.calcite.adapter.enumerable.EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE);
+    planner.removeRule(EnumerableRules.ENUMERABLE_MERGE_JOIN_RULE);
 
     // This rule does not handle SArg filters correctly, which causes filters to not
     // get pushed

--- a/adapter/src/main/java/com/twilio/kudu/sql/SqlUtil.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/SqlUtil.java
@@ -22,8 +22,13 @@ import org.apache.kudu.Type;
 
 import java.math.BigDecimal;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class SqlUtil {
   public static String getExplainPlan(ResultSet rs) throws SQLException {
@@ -36,6 +41,19 @@ public class SqlUtil {
       buf.setLength(buf.length() - 1);
     }
     return buf.toString();
+  }
+
+  public static List<List<Object>> getResult(ResultSet rs) throws SQLException {
+    int numCols = rs.getMetaData().getColumnCount();
+    List<List<Object>> rows = new ArrayList<>();
+    while (rs.next()) {
+      List<Object> row = new ArrayList<>(numCols);
+      for (int i=1; i<=numCols; ++i) {
+        row.add(rs.getObject(i));
+      }
+      rows.add(row);
+    }
+    return rows;
   }
 
   /**

--- a/adapter/src/main/java/com/twilio/kudu/sql/SqlUtil.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/SqlUtil.java
@@ -48,7 +48,7 @@ public class SqlUtil {
     List<List<Object>> rows = new ArrayList<>();
     while (rs.next()) {
       List<Object> row = new ArrayList<>(numCols);
-      for (int i=1; i<=numCols; ++i) {
+      for (int i = 1; i <= numCols; ++i) {
         row.add(rs.getObject(i));
       }
       rows.add(row);

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
@@ -56,8 +56,8 @@ public class KuduNestedJoinRule extends RelOptRule {
   public boolean matches(final RelOptRuleCall call) {
     final Join join = call.rel(0);
     // only match this rule if a hint is specified
-    if (!join.getHints().stream().map(h -> h.hintName).anyMatch( s -> s.equalsIgnoreCase(HINT_NAME))
-      || (join.getJoinType() != JoinRelType.INNER && join.getJoinType() != JoinRelType.LEFT)) {
+    if (!join.getHints().stream().map(h -> h.hintName).anyMatch(s -> s.equalsIgnoreCase(HINT_NAME))
+        || (join.getJoinType() != JoinRelType.INNER && join.getJoinType() != JoinRelType.LEFT)) {
       return false;
     }
 
@@ -98,11 +98,7 @@ public class KuduNestedJoinRule extends RelOptRule {
     List<RelNode> newInputs = new ArrayList<>();
     for (RelNode input : join.getInputs()) {
       if (!(input.getConvention() instanceof EnumerableConvention)) {
-        input =
-          convert(
-            input,
-            input.getTraitSet()
-              .replace(EnumerableConvention.INSTANCE));
+        input = convert(input, input.getTraitSet().replace(EnumerableConvention.INSTANCE));
       }
       newInputs.add(input);
     }
@@ -111,8 +107,7 @@ public class KuduNestedJoinRule extends RelOptRule {
 
     final JoinRelType joinType = join.getJoinType();
 
-    final KuduNestedJoin newJoin = KuduNestedJoin.create(left, right,
-      join.getCondition(), joinType, this.batchSize);
+    final KuduNestedJoin newJoin = KuduNestedJoin.create(left, right, join.getCondition(), joinType, this.batchSize);
 
     call.transformTo(newJoin);
   }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
@@ -38,7 +38,7 @@ public class KuduNestedJoinRule extends RelOptRule {
   public final static EnumSet<SqlKind> VALID_CALL_TYPES = EnumSet.of(SqlKind.EQUALS, SqlKind.GREATER_THAN,
       SqlKind.GREATER_THAN_OR_EQUAL, SqlKind.LESS_THAN, SqlKind.LESS_THAN_OR_EQUAL);
 
-  public static final int DEFAULT_BATCH_SIZE = 5;
+  public static final int DEFAULT_BATCH_SIZE = 100;
   private int batchSize;
 
   public static final String HINT_NAME = "USE_KUDU_NESTED_JOIN";
@@ -87,7 +87,9 @@ public class KuduNestedJoinRule extends RelOptRule {
       }
     };
 
-    return condition.accept(validateJoinCondition);
+    final Boolean isValid = condition.accept(validateJoinCondition);
+
+    return isValid != null && isValid;
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduNestedJoinRule.java
@@ -14,14 +14,14 @@
  */
 package com.twilio.kudu.sql.rules;
 
-import java.util.EnumSet;
-
 import com.twilio.kudu.sql.rel.KuduNestedJoin;
-
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
@@ -30,28 +30,34 @@ import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.tools.RelBuilderFactory;
 
-// @TODO: this rule is primed to be moved into our internal project and out of OSS.
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
 public class KuduNestedJoinRule extends RelOptRule {
   public final static EnumSet<SqlKind> VALID_CALL_TYPES = EnumSet.of(SqlKind.EQUALS, SqlKind.GREATER_THAN,
       SqlKind.GREATER_THAN_OR_EQUAL, SqlKind.LESS_THAN, SqlKind.LESS_THAN_OR_EQUAL);
 
-  public static final int DEFAULT_BATCH_SIZE = 100;
+  public static final int DEFAULT_BATCH_SIZE = 5;
   private int batchSize;
+
+  public static final String HINT_NAME = "USE_KUDU_NESTED_JOIN";
 
   public KuduNestedJoinRule(RelBuilderFactory relBuilderFactory) {
     this(relBuilderFactory, DEFAULT_BATCH_SIZE);
   }
 
   public KuduNestedJoinRule(RelBuilderFactory relBuilderFactory, final int batchSize) {
-    super(operand(Join.class, any()), relBuilderFactory, "KuduNestedLoopRule");
+    super(operand(LogicalJoin.class, any()), relBuilderFactory, "KuduNestedJoinRule");
     this.batchSize = DEFAULT_BATCH_SIZE;
   }
 
   @Override
   public boolean matches(final RelOptRuleCall call) {
     final Join join = call.rel(0);
-
-    if (join.getJoinType() != JoinRelType.INNER && join.getJoinType() != JoinRelType.LEFT) {
+    // only match this rule if a hint is specified
+    if (!join.getHints().stream().map(h -> h.hintName).anyMatch( s -> s.equalsIgnoreCase(HINT_NAME))
+      || (join.getJoinType() != JoinRelType.INNER && join.getJoinType() != JoinRelType.LEFT)) {
       return false;
     }
 
@@ -81,24 +87,32 @@ public class KuduNestedJoinRule extends RelOptRule {
       }
     };
 
-    final Boolean isValid = condition.accept(validateJoinCondition);
-
-    // @TODO: Hack for the moment.
-    final boolean containsActorSid = join.getRight().getRowType().getFieldList().stream()
-        .anyMatch(fl -> fl.getName().equalsIgnoreCase("actor_sid"));
-
-    return isValid != null && isValid && containsActorSid;
+    return condition.accept(validateJoinCondition);
   }
 
   @Override
   public void onMatch(final RelOptRuleCall call) {
-    final Join join = call.rel(0);
+    LogicalJoin join = call.rel(0);
+    List<RelNode> newInputs = new ArrayList<>();
+    for (RelNode input : join.getInputs()) {
+      if (!(input.getConvention() instanceof EnumerableConvention)) {
+        input =
+          convert(
+            input,
+            input.getTraitSet()
+              .replace(EnumerableConvention.INSTANCE));
+      }
+      newInputs.add(input);
+    }
+    final RelNode left = newInputs.get(0);
+    final RelNode right = newInputs.get(1);
 
     final JoinRelType joinType = join.getJoinType();
 
-    final KuduNestedJoin newJoin = KuduNestedJoin.create(join.getLeft(), join.getRight(), join.getCondition(), joinType,
-        this.batchSize);
+    final KuduNestedJoin newJoin = KuduNestedJoin.create(left, right,
+      join.getCondition(), joinType, this.batchSize);
 
     call.transformTo(newJoin);
   }
+
 }

--- a/adapter/src/main/java/org/apache/calcite/jdbc/KuduDriver.java
+++ b/adapter/src/main/java/org/apache/calcite/jdbc/KuduDriver.java
@@ -14,7 +14,7 @@
  */
 package org.apache.calcite.jdbc;
 
-import com.twilio.kudu.sql.KuduPrepareImpl;
+import org.apache.calcite.prepare.KuduPrepareImpl;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.linq4j.function.Function0;

--- a/adapter/src/main/java/org/apache/calcite/prepare/KuduPrepareImpl.java
+++ b/adapter/src/main/java/org/apache/calcite/prepare/KuduPrepareImpl.java
@@ -12,15 +12,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.twilio.kudu.sql;
+package org.apache.calcite.prepare;
 
 import com.google.common.collect.ImmutableMap;
+import com.twilio.kudu.sql.CalciteKuduTable;
 import com.twilio.kudu.sql.parser.SortOrder;
 import com.twilio.kudu.sql.parser.SqlAlterTable;
 import com.twilio.kudu.sql.parser.SqlCreateMaterializedView;
 import com.twilio.kudu.sql.parser.SqlCreateTable;
 import com.twilio.kudu.sql.schema.KuduSchema;
-import org.apache.calcite.prepare.CalcitePrepareImpl;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.hint.HintPredicates;
+import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlColumnDefInPkConstraintNode;
@@ -33,6 +36,8 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOptionNode;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.calcite.util.ImmutableBeans;
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.Common;
 import org.apache.kudu.Schema;
@@ -42,9 +47,10 @@ import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
 import org.json.JSONObject;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -469,6 +475,33 @@ public class KuduPrepareImpl extends CalcitePrepareImpl {
       }
     }
     throw new RuntimeException("Unable to find KuduSchema in " + rootSchema);
+  }
+
+  static void setFinalStatic(Field field, Object newValue) throws Exception {
+    field.setAccessible(true);
+
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+    field.set(null, newValue);
+  }
+
+  // TODO figure out a better way to set the HintStrategyTable for sql queries
+  static {
+    try {
+      HintStrategyTable hintStrategyTable = HintStrategyTable.builder().hintStrategy(
+        "USE_KUDU_NESTED_JOIN", HintPredicates.JOIN).build();
+      SqlToRelConverter.Config CONFIG_MODIFIED =
+        ImmutableBeans.create(SqlToRelConverter.Config.class)
+          .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
+          .withRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
+          .withHintStrategyTable(hintStrategyTable);
+      // change SqlToRelConverter.CONFIG to use one that has the above HintStrategyTable
+      setFinalStatic(SqlToRelConverter.class.getDeclaredField("CONFIG"), CONFIG_MODIFIED);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/adapter/src/main/java/org/apache/calcite/prepare/KuduPrepareImpl.java
+++ b/adapter/src/main/java/org/apache/calcite/prepare/KuduPrepareImpl.java
@@ -490,14 +490,13 @@ public class KuduPrepareImpl extends CalcitePrepareImpl {
   // TODO figure out a better way to set the HintStrategyTable for sql queries
   static {
     try {
-      HintStrategyTable hintStrategyTable = HintStrategyTable.builder().hintStrategy(
-        "USE_KUDU_NESTED_JOIN", HintPredicates.JOIN).build();
-      SqlToRelConverter.Config CONFIG_MODIFIED =
-        ImmutableBeans.create(SqlToRelConverter.Config.class)
+      HintStrategyTable hintStrategyTable = HintStrategyTable.builder()
+          .hintStrategy("USE_KUDU_NESTED_JOIN", HintPredicates.JOIN).build();
+      SqlToRelConverter.Config CONFIG_MODIFIED = ImmutableBeans.create(SqlToRelConverter.Config.class)
           .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
-          .withRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
-          .withHintStrategyTable(hintStrategyTable);
-      // change SqlToRelConverter.CONFIG to use one that has the above HintStrategyTable
+          .withRelBuilderConfigTransform(c -> c.withPushJoinCondition(true)).withHintStrategyTable(hintStrategyTable);
+      // change SqlToRelConverter.CONFIG to use one that has the above
+      // HintStrategyTable
       setFinalStatic(SqlToRelConverter.class.getDeclaredField("CONFIG"), CONFIG_MODIFIED);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/adapter/src/test/java/com/twilio/kudu/sql/ScenarioIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/ScenarioIT.java
@@ -26,8 +26,10 @@ import org.junit.Test;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -141,9 +143,91 @@ public class ScenarioIT {
   }
 
   @Test
+  public void testKuduNestedLoopJoin() throws Exception {
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      String ddl = "CREATE TABLE \"ReportCenter.UsageReportTransactions\" (" + "\"usage_account_sid\" VARCHAR, "
+        + "\"date_initiated\" TIMESTAMP DESC ROW_TIMESTAMP, " + "\"transaction_id\" VARCHAR, "
+        + "\"units\" SMALLINT, " + "\"billable_item\" VARCHAR, " + "\"calculated_sid\" VARCHAR, "
+        + "\"sub_account_sid\" VARCHAR, " + "\"phonenumber\" VARCHAR, " + "\"to\" VARCHAR, " + "\"from\" VARCHAR, "
+        + "\"amount\" DECIMAL(22, 6), " + "\"quantity\" DECIMAL(22, 6), "
+        + "PRIMARY KEY (\"usage_account_sid\", \"date_initiated\", \"transaction_id\"))"
+        + "PARTITION BY HASH (\"usage_account_sid\") PARTITIONS 2 NUM_REPLICAS 1";
+      conn.createStatement().execute(ddl);
+
+      String ddl2 = "CREATE TABLE \"OrganizationAccounts\" (" +
+        "\"organization_sid\" VARCHAR, "
+        + "\"account_sid\" VARCHAR, "
+        + "PRIMARY KEY (\"organization_sid\", \"account_sid\"))"
+        + "PARTITION BY HASH (\"organization_sid\") PARTITIONS 2 NUM_REPLICAS 1";
+      conn.createStatement().execute(ddl2);
+      // create an organization with the two accounts used to load data
+      PreparedStatement stmt = conn
+        .prepareStatement("INSERT INTO \"OrganizationAccounts\" " + "VALUES (?,?)");
+      stmt.setString(1, "ORGANIZATION_1");
+      stmt.setString(2, "ACCOUNT_1");
+      stmt.execute();stmt.setString(1, "ORGANIZATION_1");
+      stmt.setString(2, "ACCOUNT_2");
+      stmt.execute();
+      conn.commit();
+
+      Scenario scenario = Scenario
+        .loadScenario(this.getClass().getResource("/scenarios/ReportCenter.UsageReportTransactions.json"));
+      // load data
+      new DataLoader(JDBC_URL, scenario).loadData(Optional.empty());
+
+      String sqlFormat = "SELECT %s" +
+        "USAGE_ACCOUNT_SID, SUM(\"quantity\") AS \"SUM_QUANTITY\" FROM \"OrganizationAccounts\" " +
+        "JOIN \"ReportCenter.UsageReportTransactions\"  ON \"USAGE_ACCOUNT_SID\"  =  \"OrganizationAccounts\".ACCOUNT_SID" +
+        " WHERE  ORGANIZATION_SID='ORGANIZATION_1'" +
+        " AND \"DATE_INITIATED\" >= TIMESTAMP '2020-06-01 00:00:00'" +
+        " AND \"DATE_INITIATED\" < TIMESTAMP '2020-06-15 00:00:00'" +
+        " GROUP BY USAGE_ACCOUNT_SID";
+
+      // force the plan to use KuduNestedJoin
+      String hint = "/*+ USE_KUDU_NESTED_JOIN */";
+      String expectedPlan = "EnumerableAggregate(group=[{0}], SUM_QUANTITY=[SUM($1)])\n" +
+        "  EnumerableCalc(expr#0..4=[{inputs}], USAGE_ACCOUNT_SID=[$t2], QUANTITY=[$t4])\n" +
+        "    KuduNestedJoin(condition=[=($2, $1)], joinType=[inner], batchSize=[5])\n" +
+        "      KuduToEnumerableRel\n" +
+        "        KuduFilterRel(ScanToken 1=[organization_sid EQUAL ORGANIZATION_1])\n" +
+        "          KuduQuery(table=[[kudu, OrganizationAccounts]])\n" +
+        "      KuduToEnumerableRel\n" +
+        "        KuduProjectRel(USAGE_ACCOUNT_SID=[$0], DATE_INITIATED=[$1], QUANTITY=[$11])\n" +
+        "          KuduFilterRel(ScanToken 1=[date_initiated GREATER_EQUAL 1590969600000000, date_initiated LESS 1592179200000000])\n" +
+        "            KuduQuery(table=[[kudu, ReportCenter.UsageReportTransactions]])\n";
+      String sql = String.format(sqlFormat, hint);
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      String plan = SqlUtil.getExplainPlan(rs);
+      assertEquals("Plan does not match", expectedPlan, plan);
+      rs = conn.createStatement().executeQuery(sql);
+      List<List<Object>> kuduNestedJoinResult = SqlUtil.getResult(rs);
+
+      // running the query without the hint should use the regular EnumerableHashJoin
+      sql = String.format(sqlFormat, "");
+      expectedPlan = "EnumerableAggregate(group=[{0}], SUM_QUANTITY=[SUM($1)])\n" +
+        "  EnumerableCalc(expr#0..4=[{inputs}], USAGE_ACCOUNT_SID=[$t2], QUANTITY=[$t4])\n" +
+        "    EnumerableHashJoin(condition=[=($1, $2)], joinType=[inner])\n" +
+        "      KuduToEnumerableRel\n" +
+        "        KuduFilterRel(ScanToken 1=[organization_sid EQUAL ORGANIZATION_1])\n" +
+        "          KuduQuery(table=[[kudu, OrganizationAccounts]])\n" +
+        "      KuduToEnumerableRel\n" +
+        "        KuduProjectRel(USAGE_ACCOUNT_SID=[$0], DATE_INITIATED=[$1], QUANTITY=[$11])\n" +
+        "          KuduFilterRel(ScanToken 1=[date_initiated GREATER_EQUAL 1590969600000000, date_initiated LESS 1592179200000000])\n" +
+        "            KuduQuery(table=[[kudu, ReportCenter.UsageReportTransactions]])\n";
+      rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      plan = SqlUtil.getExplainPlan(rs);
+      assertEquals("Plan does not match", expectedPlan, plan);
+      rs = conn.createStatement().executeQuery(sql);
+      List<List<Object>> hashJoinResult = SqlUtil.getResult(rs);
+
+      assertEquals("Results do no match", hashJoinResult, kuduNestedJoinResult);
+    }
+  }
+
+  @Test
   public void testUsageReportTransactions() throws IOException, SQLException {
     Scenario scenario = Scenario
-        .loadScenario(this.getClass().getResource("/scenarios/ReportCenter" + ".UsageReportTransactions.json"));
+        .loadScenario(this.getClass().getResource("/scenarios/ReportCenter.UsageReportTransactions.json"));
 
     // verify data was written
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {

--- a/adapter/src/test/java/com/twilio/kudu/sql/ScenarioIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/ScenarioIT.java
@@ -181,15 +181,16 @@ public class ScenarioIT {
 
       // force the plan to use KuduNestedJoin
       String hint = "/*+ USE_KUDU_NESTED_JOIN */";
-      String expectedPlan = "EnumerableAggregate(group=[{0}], SUM_QUANTITY=[SUM($1)])\n"
-          + "  EnumerableCalc(expr#0..4=[{inputs}], USAGE_ACCOUNT_SID=[$t2], QUANTITY=[$t4])\n"
-          + "    KuduNestedJoin(condition=[=($2, $1)], joinType=[inner], batchSize=[5])\n"
-          + "      KuduToEnumerableRel\n"
-          + "        KuduFilterRel(ScanToken 1=[organization_sid EQUAL ORGANIZATION_1])\n"
-          + "          KuduQuery(table=[[kudu, OrganizationAccounts]])\n" + "      KuduToEnumerableRel\n"
-          + "        KuduProjectRel(USAGE_ACCOUNT_SID=[$0], DATE_INITIATED=[$1], QUANTITY=[$11])\n"
-          + "          KuduFilterRel(ScanToken 1=[date_initiated GREATER_EQUAL 1590969600000000, date_initiated LESS 1592179200000000])\n"
-          + "            KuduQuery(table=[[kudu, ReportCenter.UsageReportTransactions]])\n";
+      String expectedPlan = "EnumerableAggregate(group=[{0}], SUM_QUANTITY=[SUM($1)])\n" +
+        "  EnumerableCalc(expr#0..4=[{inputs}], USAGE_ACCOUNT_SID=[$t2], QUANTITY=[$t4])\n" +
+        "    KuduNestedJoin(condition=[=($2, $1)], joinType=[inner], batchSize=[100])\n" +
+        "      KuduToEnumerableRel\n" +
+        "        KuduFilterRel(ScanToken 1=[organization_sid EQUAL ORGANIZATION_1])\n" +
+        "          KuduQuery(table=[[kudu, OrganizationAccounts]])\n" +
+        "      KuduToEnumerableRel\n" +
+        "        KuduProjectRel(USAGE_ACCOUNT_SID=[$0], DATE_INITIATED=[$1], QUANTITY=[$11])\n" +
+        "          KuduFilterRel(ScanToken 1=[date_initiated GREATER_EQUAL 1590969600000000, date_initiated LESS 1592179200000000])\n" +
+        "            KuduQuery(table=[[kudu, ReportCenter.UsageReportTransactions]])\n";
       String sql = String.format(sqlFormat, hint);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);

--- a/adapter/src/test/java/com/twilio/kudu/sql/ScenarioIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/ScenarioIT.java
@@ -181,16 +181,15 @@ public class ScenarioIT {
 
       // force the plan to use KuduNestedJoin
       String hint = "/*+ USE_KUDU_NESTED_JOIN */";
-      String expectedPlan = "EnumerableAggregate(group=[{0}], SUM_QUANTITY=[SUM($1)])\n" +
-        "  EnumerableCalc(expr#0..4=[{inputs}], USAGE_ACCOUNT_SID=[$t2], QUANTITY=[$t4])\n" +
-        "    KuduNestedJoin(condition=[=($2, $1)], joinType=[inner], batchSize=[100])\n" +
-        "      KuduToEnumerableRel\n" +
-        "        KuduFilterRel(ScanToken 1=[organization_sid EQUAL ORGANIZATION_1])\n" +
-        "          KuduQuery(table=[[kudu, OrganizationAccounts]])\n" +
-        "      KuduToEnumerableRel\n" +
-        "        KuduProjectRel(USAGE_ACCOUNT_SID=[$0], DATE_INITIATED=[$1], QUANTITY=[$11])\n" +
-        "          KuduFilterRel(ScanToken 1=[date_initiated GREATER_EQUAL 1590969600000000, date_initiated LESS 1592179200000000])\n" +
-        "            KuduQuery(table=[[kudu, ReportCenter.UsageReportTransactions]])\n";
+      String expectedPlan = "EnumerableAggregate(group=[{0}], SUM_QUANTITY=[SUM($1)])\n"
+          + "  EnumerableCalc(expr#0..4=[{inputs}], USAGE_ACCOUNT_SID=[$t2], QUANTITY=[$t4])\n"
+          + "    KuduNestedJoin(condition=[=($2, $1)], joinType=[inner], batchSize=[100])\n"
+          + "      KuduToEnumerableRel\n"
+          + "        KuduFilterRel(ScanToken 1=[organization_sid EQUAL ORGANIZATION_1])\n"
+          + "          KuduQuery(table=[[kudu, OrganizationAccounts]])\n" + "      KuduToEnumerableRel\n"
+          + "        KuduProjectRel(USAGE_ACCOUNT_SID=[$0], DATE_INITIATED=[$1], QUANTITY=[$11])\n"
+          + "          KuduFilterRel(ScanToken 1=[date_initiated GREATER_EQUAL 1590969600000000, date_initiated LESS 1592179200000000])\n"
+          + "            KuduQuery(table=[[kudu, ReportCenter.UsageReportTransactions]])\n";
       String sql = String.format(sqlFormat, hint);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);

--- a/adapter/src/test/resources/scenarios/ReportCenter.UsageReportTransactions.json
+++ b/adapter/src/test/resources/scenarios/ReportCenter.UsageReportTransactions.json
@@ -7,8 +7,8 @@
       "sidPrefix" : "TX"
     },
     "usage_account_sid" : {
-      "type" : "ConstantValueGenerator",
-      "columnValue" : "AC1231ebbfc4cd2fc2485ed634000001001"
+      "type" : "ValueListGenerator",
+      "values" : ["ACCOUNT_1", "ACCOUNT_2"]
     },
     "date_initiated" : {
       "type" : "UniformLongValueGenerator",


### PR DESCRIPTION
Add a hint that can be used to force a query to use KuduNestedJoin (by default the EnumerableHashJoin is used). 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
