### PR TITLE
Add Enumerable Rules only when enumerable is enabled

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Sets;
 import com.twilio.kudu.sql.rules.KuduNestedJoinRule;
 import com.twilio.kudu.sql.rules.KuduRules;
 import org.apache.calcite.adapter.enumerable.EnumerableRules;
+import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
@@ -104,8 +105,10 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
     // KuduFilterIntoJoinRule which expands SArgs
     planner.removeRule(CoreRules.FILTER_INTO_JOIN);
 
-    for (RelOptRule rule : KuduRules.RULES) {
-      planner.addRule(rule);
+    KuduRules.CORE_RULES.stream().forEach(rule -> planner.addRule(rule));
+
+    if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()) {
+      KuduRules.ENUMERABLE_RULES.stream().forEach(r -> planner.addRule(r));
     }
   }
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
@@ -30,8 +30,8 @@ public class KuduRules {
   public static final RelOptRule SORT_OVER_JOIN_TRANSPOSE = new SortInnerJoinTranspose(RelFactories.LOGICAL_BUILDER);
   public static final KuduNestedJoinRule NESTED_JOIN = new KuduNestedJoinRule(RelFactories.LOGICAL_BUILDER);
 
-  public static List<RelOptRule> RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
+  public static List<RelOptRule> ENUMERABLE_RULES = Arrays.asList(NESTED_JOIN, KuduToEnumerableConverter.INSTANCE);
+  public static List<RelOptRule> CORE_RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
       SORT_OVER_JOIN_TRANSPOSE, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
-      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, NESTED_JOIN, KuduToEnumerableConverter.INSTANCE,
-      KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
+      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
 }


### PR DESCRIPTION
## Why:
Working on a non-enumerable convention and would like to ensure the
Enumerable Rules are not enabled in that planner

## How:
Uses the `CalciteSystemProperty#ENABLE_ENUMERABLE` to check for
EnumerableRules that are being activated. This is used in
`RelOptUtil#registerDefaultRules` as well:
https://github.com/apache/calcite/blob/4bc916619fd286b2c0cc4d5c653c96a68801d74e/core/src/main/java/org/apache/calcite/plan/RelOptUtil.java#L2084-L2087


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
