### PR TITLE
Add KuduAggregationLimitRule

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -20,6 +20,7 @@ import com.twilio.kudu.sql.rules.KuduPredicatePushDownVisitor;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.EnumerableDefaults;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.kudu.client.KuduScanner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,6 +79,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
 
   public final boolean sort;
   public final boolean groupBySorted;
+  public final Function1<Object, Object> sortedPrefixKeySelector;
   public final long limit;
   public final long offset;
   public final KuduScanStats scanStats;
@@ -94,35 +96,41 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
   /**
    * A KuduEnumerable is an {@link Enumerable} for Kudu that can be configured to
    * be sorted.
-   *
-   * @param predicates       list of the filters for each disjoint Kudu Scan
-   * @param columnIndices    the column indexes to fetch from the table
-   * @param client           Kudu client that will execute the scans
-   * @param calciteKuduTable table metadata for the scan
-   * @param limit            the number of rows this should return. -1 indicates
-   *                         no limit
-   * @param offset           the number of rows from kudu to skip prior to
-   *                         returning rows
-   * @param sort             whether or not have Kudu RPCs come back in sorted by
-   *                         primary key
-   * @param groupBySorted    when sorted, and
-   *                         {@link Enumerable#groupBy(Function1, Function0, Function2, Function2)}
-   * @param scanStats        a container of scan stats that should be updated as
-   *                         the scan executes.
-   * @param cancelFlag       boolean indicating the end process has asked the
-   *                         query to finish.
-   * @param projection       function to translate
-   *                         {@link org.apache.kudu.client.RowResult} into Calcite
-   * @param filterFunction   filter applied to every
-   *                         {@link org.apache.kudu.client.RowResult}
-   * @param isSingleObject   whether or not Calcite object is an Object or an
-   *                         Object[]
+   * 
+   * @param predicates              list of the filters for each disjoint Kudu
+   *                                Scan
+   * @param columnIndices           the column indexes to fetch from the table
+   * @param client                  Kudu client that will execute the scans
+   * @param calciteKuduTable        table metadata for the scan
+   * @param limit                   the number of rows this should return. -1
+   *                                indicates no limit
+   * @param offset                  the number of rows from kudu to skip prior to
+   *                                returning rows
+   * @param sort                    whether or not have Kudu RPCs come back in
+   *                                sorted by primary key
+   * @param groupBySorted           when sorted, and
+   *                                {@link Enumerable#groupBy(Function1, Function0, Function2, Function2)}
+   * @param scanStats               a container of scan stats that should be
+   *                                updated as the scan executes.
+   * @param cancelFlag              boolean indicating the end process has asked
+   *                                the query to finish.
+   * @param projection              function to translate
+   *                                {@link org.apache.kudu.client.RowResult} into
+   *                                Calcite
+   * @param filterFunction          filter applied to every
+   *                                {@link org.apache.kudu.client.RowResult}
+   * @param isSingleObject          whether or not Calcite object is an Object or
+   *                                an
+   * @param sortedPrefixKeySelector the subset of columns being sorted by that are
+   *                                a prefix of the primary key of the table, or
+   *                                an empty list if the group by and order by
+   *                                columns are the same
    */
   public KuduEnumerable(final List<List<CalciteKuduPredicate>> predicates, final List<Integer> columnIndices,
       final AsyncKuduClient client, final CalciteKuduTable calciteKuduTable, final long limit, final long offset,
       final boolean sort, final boolean groupBySorted, final KuduScanStats scanStats, final AtomicBoolean cancelFlag,
-      final Function1<Object, Object> projection, final Predicate1<Object> filterFunction,
-      final boolean isSingleObject) {
+      final Function1<Object, Object> projection, final Predicate1<Object> filterFunction, final boolean isSingleObject,
+      final Function1<Object, Object> sortedPrefixKeySelector) {
     this.scansShouldStop = new AtomicBoolean(false);
     this.cancelFlag = cancelFlag;
     this.limit = limit;
@@ -136,6 +144,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
       throw new IllegalArgumentException("If groupBySorted is true the results must need to be " + "sorted");
     }
     this.groupBySorted = groupBySorted;
+    this.sortedPrefixKeySelector = sortedPrefixKeySelector;
     this.scanStats = scanStats;
 
     this.predicates = predicates;
@@ -412,10 +421,11 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
 
     int uniqueGroupCount = 0;
     TKey lastKey = null;
+    Object lastSortedKey = null;
 
     // groupFetchLimit calculates it's size based on offset. When offset is present,
     // it needs to
-    // skip an equalivent number of unique group keys
+    // skip an equivalent number of unique group keys
     long groupFetchLimit = Long.MAX_VALUE;
     if (offset > 0 && limit > 0) {
       groupFetchLimit = limit + offset;
@@ -433,6 +443,20 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
         Object o = objectEnumeration.current();
         final TKey key = keySelector.apply(o);
 
+        if (sortedPrefixKeySelector != null) {
+          final Object sortedKey = sortedPrefixKeySelector.apply(o);
+          // If sortedPrefixKeySelector is not null, we can only stop reading rows when
+          // the
+          // sorted key prefix changes and we have enough unique groups since the rows
+          // have to be
+          // sorted on the client we have to read all the rows that have the same sorted
+          // primary key prefix)
+          if (lastSortedKey != null && !sortedKey.equals(lastSortedKey) && uniqueGroupCount > groupFetchLimit) {
+            break;
+          }
+          lastSortedKey = sortedKey;
+        }
+
         // If there hasn't been a key yet or if there is a new key
         if (lastKey == null || !key.equals(lastKey)) {
           // If there is an accumulator, save the results into the queue and reset
@@ -441,20 +465,24 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
             sortedResults.offer(resultSelector.apply(lastKey, accumulator));
             accumulator = null;
           }
-
           uniqueGroupCount++;
 
+          // sortedPrefixKeySelector is null means we don't have to sort results on the
+          // client
           // When we have seen limit + 1 unique group by keys, exit.
           // or in the case of an offset, limit + offset + 1 unique group by keys.
-          if (uniqueGroupCount > groupFetchLimit) {
+          if (sortedPrefixKeySelector == null && uniqueGroupCount > groupFetchLimit) {
             break;
           }
 
           lastKey = key;
         }
 
-        // When we are still skipping group by keys.
-        if (offset > 0 && uniqueGroupCount <= offset) {
+        // We can only skip rows if we don't need to sort the returned rows on the
+        // client
+        // (sortedPrefixKeySelector is null)
+        if (sortedPrefixKeySelector == null && offset > 0 && uniqueGroupCount <= offset) {
+          // We are still skipping group by keys.
           continue;
         }
 
@@ -543,12 +571,12 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
     final List<List<CalciteKuduPredicate>> merged = KuduPredicatePushDownVisitor.mergePredicateLists(SqlKind.AND,
         this.predicates, conjunctions);
     return new KuduEnumerable(merged, columnIndices, client, calciteKuduTable, limit, offset, sort, groupBySorted,
-        scanStats, cancelFlag, projection, filterFunction, isSingleObject);
+        scanStats, cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector);
   }
 
   /**
-   * Return a function that accepts the Left hand sides rows and creates a new
-   * {@code SortableEnumerable} that will match the batch of rows.
+   * Return a function that accepts the Left hand sides rows and creates a
+   * newsorted {@code SortableEnumerable} that will match the batch of rows.
    *
    * @param joinNode The {@link Join} relation for this nest join.
    *

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -452,12 +452,13 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           // sorted on the client we have to read all the rows that have the same sorted
           // primary key prefix)
           if (lastSortedKey != null && !sortedKey.equals(lastSortedKey) && uniqueGroupCount > groupFetchLimit) {
-            logger.info("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}", sortedKey,
+            logger.debug("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}",
+              sortedKey,
                 lastSortedKey, uniqueGroupCount, groupFetchLimit);
             break;
           }
           lastSortedKey = sortedKey;
-          logger.info("sortedKey {} uniqueGroupCount{}", sortedKey, uniqueGroupCount);
+          logger.debug("sortedKey {} uniqueGroupCount{}", sortedKey, uniqueGroupCount);
         }
 
         // If there hasn't been a key yet or if there is a new key
@@ -477,7 +478,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           if (sortedPrefixKeySelector == null && uniqueGroupCount > groupFetchLimit) {
             break;
           }
-          logger.info("key {} uniqueGroupCount{}", key, uniqueGroupCount);
+          logger.debug("key {} uniqueGroupCount{}", key, uniqueGroupCount);
           lastKey = key;
         }
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -452,9 +452,12 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           // sorted on the client we have to read all the rows that have the same sorted
           // primary key prefix)
           if (lastSortedKey != null && !sortedKey.equals(lastSortedKey) && uniqueGroupCount > groupFetchLimit) {
+            logger.info("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}", sortedKey,
+                lastSortedKey, uniqueGroupCount, groupFetchLimit);
             break;
           }
           lastSortedKey = sortedKey;
+          logger.info("sortedKey {} uniqueGroupCount{}", sortedKey, uniqueGroupCount);
         }
 
         // If there hasn't been a key yet or if there is a new key
@@ -474,7 +477,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           if (sortedPrefixKeySelector == null && uniqueGroupCount > groupFetchLimit) {
             break;
           }
-
+          logger.info("key {} uniqueGroupCount{}", key, uniqueGroupCount);
           lastKey = key;
         }
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -452,8 +452,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           // sorted on the client we have to read all the rows that have the same sorted
           // primary key prefix)
           if (lastSortedKey != null && !sortedKey.equals(lastSortedKey) && uniqueGroupCount > groupFetchLimit) {
-            logger.debug("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}",
-              sortedKey,
+            logger.debug("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}", sortedKey,
                 lastSortedKey, uniqueGroupCount, groupFetchLimit);
             break;
           }
@@ -579,8 +578,8 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
   }
 
   /**
-   * Return a function that accepts the Left hand sides rows and creates a
-   * newsorted {@code SortableEnumerable} that will match the batch of rows.
+   * Return a function that accepts the Left hand sides rows and creates a new
+   * {@code SortableEnumerable} that will match the batch of rows.
    *
    * @param joinNode The {@link Join} relation for this nest join.
    *

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduMethod.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduMethod.java
@@ -31,7 +31,7 @@ import org.apache.calcite.rel.core.Join;
 public enum KuduMethod {
   KUDU_QUERY_METHOD(CalciteKuduTable.KuduQueryable.class, "query", List.class, List.class, int.class, int.class,
       boolean.class, boolean.class, KuduScanStats.class, AtomicBoolean.class, Function1.class, Predicate1.class,
-      boolean.class),
+      boolean.class, Function1.class),
   KUDU_MUTATE_TUPLES_METHOD(CalciteKuduTable.KuduQueryable.class, "mutateTuples", List.class, List.class),
   KUDU_MUTATE_ROW_METHOD(CalciteKuduTable.KuduQueryable.class, "mutateRow", List.class, List.class),
   NESTED_JOIN_PREDICATES(KuduEnumerable.class, "nestedJoinPredicates", Join.class);

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
@@ -15,9 +15,11 @@
 package com.twilio.kudu.sql;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.twilio.kudu.sql.rules.KuduToEnumerableConverter;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 
@@ -75,6 +77,9 @@ public interface KuduRelNode extends RelNode {
     public long offset = -1;
     public boolean sorted = false;
     public boolean groupByLimited = false;
+    // if groupByLimited is true and sortPkPrefixColumns is empty
+    // that means we are sorting by the same columns as we are grouping by
+    public List<RelFieldCollation> sortPkPrefixColumns = Collections.emptyList();
 
     // information required for executing an update
     public List<Integer> columnIndexes;

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -1,0 +1,208 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.sql.rules;
+
+import com.google.common.collect.Lists;
+import com.twilio.kudu.sql.KuduQuery;
+import com.twilio.kudu.sql.KuduRelNode;
+import com.twilio.kudu.sql.rel.KuduSortRel;
+import com.twilio.kudu.sql.rel.KuduToEnumerableRel;
+import org.apache.calcite.adapter.enumerable.EnumerableLimit;
+import org.apache.calcite.adapter.enumerable.EnumerableLimitSort;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.kudu.client.KuduTable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Rule to match a limit over a sort over aggregation. There must be a common
+ * prefix between the sort columns and the primary key columns of the table. The
+ * aggregation columns should be a a prefix of the primary key columns. For eg
+ * if a table has three columns A, B and C with a PK(A, B) this rule can be
+ * applied if sorting by (A, C) and grouping by (A, B).
+ */
+public class KuduAggregationLimitRule extends RelOptRule {
+
+  private static final RelOptRuleOperand OPERAND = operand(EnumerableLimit.class,
+      some(operand(Sort.class, some(operand(Aggregate.class, some(operand(KuduToEnumerableRel.class,
+          some(operand(Project.class, some(operand(Filter.class, some(operand(KuduQuery.class, none())))))))))))));
+
+  public static final RelOptRule AGGREGATION_LIMIT_RULE = new KuduAggregationLimitRule(RelFactories.LOGICAL_BUILDER);
+
+  public KuduAggregationLimitRule(final RelBuilderFactory factory) {
+    super(OPERAND, factory, "KuduAggregationWithLimit");
+  }
+
+  @Override
+  public void onMatch(final RelOptRuleCall call) {
+    final EnumerableLimit originalLimit = (EnumerableLimit) call.getRelList().get(0);
+    final Sort originalSort = (Sort) call.getRelList().get(1);
+    final Aggregate originalAggregate = (Aggregate) call.getRelList().get(2);
+    final KuduToEnumerableRel kuduToEnumerableRel = (KuduToEnumerableRel) call.getRelList().get(3);
+    final Project project = (Project) call.getRelList().get(4);
+    final Filter filter = (Filter) call.getRelList().get(5);
+    final KuduQuery query = (KuduQuery) call.getRelList().get(6);
+
+    perform(call, originalLimit, originalSort, originalAggregate, kuduToEnumerableRel, project, filter, query);
+  }
+
+  protected void perform(final RelOptRuleCall call, final EnumerableLimit originalLimit, final Sort originalSort,
+      final Aggregate originalAggregate, final KuduToEnumerableRel kuduToEnumerableRel, final Project project,
+      final Filter filter, final KuduQuery query) {
+
+    // Check that the columns being grouped are a prefix of the pk columns
+    int pkColumnIndex = 0;
+    List<Integer> remappedGroupOrdinals = originalAggregate.getGroupSet().asList().stream()
+        .map(groupedOrdinal -> ((RexInputRef) project.getProjects().get(groupedOrdinal)).getIndex())
+        // sort so that we can check if the group by columns match a prefix
+        .sorted().collect(Collectors.toList());
+    for (Integer remappedGroupOrdinal : remappedGroupOrdinals) {
+      // the group by columns must be a prefix of the primary key columns
+      if (remappedGroupOrdinal != pkColumnIndex) {
+        // This field is not in the primary key columns. If there is a condition lets
+        // see if it is there
+        final RexBuilder rexBuilder = filter.getCluster().getRexBuilder();
+        final RexNode originalCondition = RexUtil.expandSearch(rexBuilder, null, filter.getCondition());
+        while (pkColumnIndex < remappedGroupOrdinal) {
+          final KuduSortRule.KuduFilterVisitor visitor = new KuduSortRule.KuduFilterVisitor(pkColumnIndex);
+          final Boolean foundFieldInCondition = originalCondition.accept(visitor);
+          if (foundFieldInCondition.equals(Boolean.FALSE)) {
+            return;
+          }
+          pkColumnIndex++;
+        }
+      }
+      pkColumnIndex++;
+    }
+
+    final Map<Integer, Integer> remappingOrdinals = new HashMap<>();
+    for (RelFieldCollation fieldCollation : originalSort.getCollation().getFieldCollations()) {
+      int projectOrdinal = fieldCollation.getFieldIndex();
+      int kuduColumnIndex = ((RexInputRef) project.getProjects().get(projectOrdinal)).getIndex();
+      remappingOrdinals.put(fieldCollation.getFieldIndex(), kuduColumnIndex);
+    }
+
+    RelCollation newCollation = RelCollationTraitDef.INSTANCE
+        .canonize(RelCollations.permute(originalSort.getCollation(), remappingOrdinals));
+    final RelTraitSet traitSet = originalSort.getTraitSet().plus(newCollation).plus(Convention.NONE);
+
+    // Check the new trait set to see if we can apply the sort against this.
+    final List<RelFieldCollation> sortPrefixColumns = getSortPkPrefix(traitSet, query,
+        query.calciteKuduTable.getKuduTable(), Optional.of(filter));
+    if (sortPrefixColumns.isEmpty()) {
+      return;
+    }
+
+    // create a KuduSortRel but indicate that the input does not come out sorted so
+    // that EnumerableSort is used to sort the results
+    final KuduSortRel kuduSort = new KuduSortRel(project.getCluster(),
+        originalSort.getTraitSet().replace(KuduRelNode.CONVENTION), project, originalSort.getCollation(),
+        originalLimit.offset, originalLimit.fetch, true, sortPrefixColumns);
+
+    final RelNode newKuduToEnumerableRel = kuduToEnumerableRel.copy(kuduToEnumerableRel.getTraitSet(),
+        Lists.newArrayList(kuduSort));
+
+    final RelNode newAggregation = originalAggregate.copy(originalAggregate.getTraitSet(),
+        Collections.singletonList(newKuduToEnumerableRel));
+
+    final RelNode limitSort = EnumerableLimitSort.create(newAggregation, originalSort.getCollation(),
+        originalLimit.offset, originalLimit.fetch);
+
+    call.transformTo(limitSort);
+  }
+
+  private boolean checkSortDirection(final KuduQuery query, final RelFieldCollation sortField) {
+    // Reject for descending sorted fields if sort direction is not Descending
+    if ((query.calciteKuduTable.isColumnOrderedDesc(sortField.getFieldIndex())
+        && sortField.direction != RelFieldCollation.Direction.DESCENDING
+        && sortField.direction != RelFieldCollation.Direction.STRICTLY_DESCENDING) ||
+    // Else Reject if sort order is not ascending
+        (!query.calciteKuduTable.isColumnOrderedDesc(sortField.getFieldIndex())
+            && sortField.direction != RelFieldCollation.Direction.ASCENDING
+            && sortField.direction != RelFieldCollation.Direction.STRICTLY_ASCENDING)) {
+      return false;
+    }
+    return true;
+  }
+
+  public List<RelFieldCollation> getSortPkPrefix(final RelTraitSet sortTraits, final KuduQuery query,
+      final KuduTable openedTable, final Optional<Filter> filter) {
+    // If there is no sort -- i.e. there is only a limit
+    // don't pay the cost of returning rows in sorted order.
+    final RelCollation collation = sortTraits.getTrait(RelCollationTraitDef.INSTANCE);
+    final List<RelFieldCollation> sortPrefixColumns = Lists.newArrayList();
+
+    if (collation.getFieldCollations().isEmpty() || sortTraits.contains(KuduRelNode.CONVENTION)) {
+      return sortPrefixColumns;
+    }
+
+    int pkColumnIndex = 0;
+    for (final RelFieldCollation sortField : collation.getFieldCollations()) {
+      // the sort columns must contain a prefix of the primary key columns
+      // for eg if a table has three columns A, B and C with a PK(A, B) this rule can
+      // be applied if we sort by (A, C)
+      if (sortField.getFieldIndex() != pkColumnIndex) {
+        // This field is not in the primary key columns. If there is a condition lets
+        // see if it is there
+        if (filter.isPresent()) {
+          final RexBuilder rexBuilder = filter.get().getCluster().getRexBuilder();
+          final RexNode originalCondition = RexUtil.expandSearch(rexBuilder, null, filter.get().getCondition());
+          while (pkColumnIndex < sortField.getFieldIndex()) {
+            final KuduSortRule.KuduFilterVisitor visitor = new KuduSortRule.KuduFilterVisitor(pkColumnIndex);
+            final Boolean foundFieldInCondition = originalCondition.accept(visitor);
+            if (foundFieldInCondition.equals(Boolean.FALSE)) {
+              return sortPrefixColumns;
+            }
+            pkColumnIndex++;
+          }
+        } else {
+          break;
+        }
+      }
+      if (!checkSortDirection(query, sortField)) {
+        break;
+      }
+      sortPrefixColumns.add(sortField);
+      pkColumnIndex++;
+    }
+
+    return sortPrefixColumns;
+  }
+
+}

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -71,8 +71,8 @@ public class KuduAggregationLimitRule extends RelOptRule {
 
   @Override
   public void onMatch(final RelOptRuleCall call) {
-//    final EnumerableLimit originalLimit = (EnumerableLimit) call.getRelList().get(0);
     final Sort originalSort = (Sort) call.getRelList().get(0);
+    // if there is no LIMIT just return
     if (originalSort.fetch == null)
       return;
     final Aggregate originalAggregate = (Aggregate) call.getRelList().get(1);
@@ -170,10 +170,8 @@ public class KuduAggregationLimitRule extends RelOptRule {
 
   public List<RelFieldCollation> getSortPkPrefix(final RelCollation originalCollation, final RelCollation newCollation,
       final KuduQuery query, final Optional<Filter> filter) {
-    // If there is no sort -- i.e. there is only a limit
-    // don't pay the cost of returning rows in sorted order.
+    // If there is no sort just return
     final List<RelFieldCollation> sortPrefixColumns = Lists.newArrayList();
-
     if (newCollation.getFieldCollations().isEmpty()) {
       return sortPrefixColumns;
     }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
@@ -33,5 +33,6 @@ public class KuduRules {
   public static List<RelOptRule> ENUMERABLE_RULES = Arrays.asList(NESTED_JOIN, KuduToEnumerableConverter.INSTANCE);
   public static List<RelOptRule> CORE_RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
       SORT_OVER_JOIN_TRANSPOSE, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
-      KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE, KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
+      KuduAggregationLimitRule.AGGREGATION_LIMIT_RULE, KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE,
+      KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduRules.java
@@ -33,6 +33,5 @@ public class KuduRules {
   public static List<RelOptRule> ENUMERABLE_RULES = Arrays.asList(NESTED_JOIN, KuduToEnumerableConverter.INSTANCE);
   public static List<RelOptRule> CORE_RULES = Arrays.asList(FILTER, PROJECT, SORT, FILTER_SORT, LIMIT,
       SORT_OVER_JOIN_TRANSPOSE, KuduSortedAggregationRule.SORTED_AGGREGATION_RULE,
-      KuduAggregationLimitRule.AGGREGATION_LIMIT_RULE, KuduSortedAggregationRule.SORTED_AGGREGATION_LIMIT_RULE,
-      KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
+      KuduAggregationLimitRule.AGGREGATION_LIMIT_RULE, KuduFilterIntoJoinRule.KUDU_FILTER_INTO_JOIN);
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -75,7 +75,6 @@ public abstract class KuduSortRule extends RelOptRule {
     }
 
     int pkColumnIndex = 0;
-
     for (final RelFieldCollation sortField : collation.getFieldCollations()) {
       // Reject for descending sorted fields if sort direction is not Descending
       if ((query.calciteKuduTable.isColumnOrderedDesc(sortField.getFieldIndex())
@@ -88,6 +87,8 @@ public abstract class KuduSortRule extends RelOptRule {
         return false;
       }
       // the sort columns must be a prefix of the primary key columns
+      // for eg if a table has three columns A, B and C with a PK(A, B) this rule can
+      // be applied if we sort by (A, B)
       if (sortField.getFieldIndex() >= openedTable.getSchema().getPrimaryKeyColumnCount()
           || sortField.getFieldIndex() != pkColumnIndex) {
         // This field is not in the primary key columns. If there is a condition lets

--- a/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
@@ -279,6 +279,25 @@ public final class JDBCQueryIT {
   }
 
   @Test
+  public void testLimit() throws Exception {
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      String sqlFormat = "SELECT * FROM \"ReportCenter.DeliveredMessages\" WHERE account_sid = " + "'%s' LIMIT 2";
+      String sql = String.format(sqlFormat, JDBCQueryIT.ACCOUNT_SID);
+      String expectedPlan = "KuduToEnumerableRel\n" + "  KuduLimitRel(limit=[2])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567])\n"
+          + "      KuduQuery(table=[[kudu, ReportCenter.DeliveredMessages]])\n";
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      String plan = SqlUtil.getExplainPlan(rs);
+      assertEquals("Unexpected plan ", expectedPlan, plan);
+
+      rs = conn.createStatement().executeQuery(sql);
+      assertTrue(rs.next());
+      assertTrue(rs.next());
+      assertFalse(rs.next());
+    }
+  }
+
+  @Test
   public void testSortOnAllGroupByColumnsWithLimit() throws Exception {
     helpTestSortedAggregation(true);
   }
@@ -326,6 +345,8 @@ public final class JDBCQueryIT {
       String sqlFormat = "SELECT account_sid, error_code , count(*) FROM \"ReportCenter.DeliveredMessages\" "
           + "WHERE account_sid = '%s' GROUP BY account_sid, error_code ORDER BY " + "account_sid  LIMIT 51";
       String sql = String.format(sqlFormat, JDBCQueryIT.ACCOUNT_SID);
+      // the limit should be able to be pushed down because of
+      // KuduAggregationLimitRule
       String expectedPlan = "EnumerableLimitSort(sort0=[$0], dir0=[ASC], fetch=[51])\n"
           + "  EnumerableAggregate(group=[{0, 1}], EXPR$2=[COUNT()])\n" + "    KuduToEnumerableRel\n"
           + "      KuduProjectRel(ACCOUNT_SID=[$0], ERROR_CODE=[$5])\n"

--- a/adapter/src/test/java/com/twilio/kudu/sql/KuduQueryIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/KuduQueryIT.java
@@ -118,7 +118,7 @@ public class KuduQueryIT {
     final CalciteKuduPredicate filterToSid = new ComparisonPredicate(2, KuduPredicate.ComparisonOp.EQUAL, "SM1234857");
     final Enumerable<Object> results = relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), -1, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true, null);
     Iterator<Object> resultIter = results.iterator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.hasNext());
@@ -135,7 +135,7 @@ public class KuduQueryIT {
         KuduQueryIT.ACCOUNT_SID);
     final Enumerable<Object> results = relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToAccountSid)), Arrays.asList(2, 0), -1, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null);
     Iterator<Object> resultIter = results.iterator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.hasNext());
@@ -172,7 +172,8 @@ public class KuduQueryIT {
     predicateQuery.add(Arrays.asList(secondSid));
 
     final Enumerable<Object> results = relTable.executeQuery(predicateQuery, Collections.singletonList(2), -1, -1,
-        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true);
+        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true,
+        null);
     Enumerator<Object> resultIter = results.enumerator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.moveNext());
@@ -198,14 +199,14 @@ public class KuduQueryIT {
     // RelCollation
     KuduEnumerable kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals("Each scanner should have pushed down the limit of 3 into the scan", 3L, scanner.getLimit());
     }
 
     kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, 4, true,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals("Each scanner should have pushed down the limit of 3 and offset of 4 into the scan", 3L + 4L,
           scanner.getLimit());
@@ -214,7 +215,7 @@ public class KuduQueryIT {
     // since we sorting assert that the limit is pushed down into the kudu scanner
     kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, -1, true,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals(3, scanner.getLimit());
     }
@@ -223,7 +224,7 @@ public class KuduQueryIT {
     // a sort
     kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), -1, 1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null);
     Assert.assertTrue(kuduEnumerable.sort);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals(Long.MAX_VALUE, scanner.getLimit());
@@ -251,7 +252,8 @@ public class KuduQueryIT {
     predicateQuery.add(Arrays.asList(secondSid));
 
     final Enumerable<Object> results = relTable.executeQuery(predicateQuery, Collections.singletonList(2), -1, -1,
-        false, false, new KuduScanStats(), new AtomicBoolean(true), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false);
+        false, false, new KuduScanStats(), new AtomicBoolean(true), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false,
+        null);
     Enumerator<Object> resultIter = results.enumerator();
 
     Assert.assertFalse("Query was canceled, it should not have anything to move over", resultIter.moveNext());
@@ -272,7 +274,7 @@ public class KuduQueryIT {
         KuduQueryIT.ACCOUNT_SID);
     final Enumerable<Object> results = relTable.executeQuery(
         Collections.singletonList(Collections.singletonList(filterToAccountSid)), Arrays.asList(2, 0), -1, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true);
+        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true, null);
     Iterator<Object> resultIter = results.iterator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.hasNext());

--- a/adapter/src/test/java/com/twilio/kudu/sql/SortedAggregationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/SortedAggregationIT.java
@@ -54,10 +54,10 @@ public final class SortedAggregationIT {
     System.setProperty("org.codehaus.janino.source_debugging.enable", "true");
     final List<ColumnSchema> columns = Arrays.asList(
         new ColumnSchema.ColumnSchemaBuilder("ACCOUNT_SID", Type.STRING).key(true).build(),
-        new ColumnSchema.ColumnSchemaBuilder("REVERSE_BYTE_FIELD", Type.INT8).key(true).build(),
-        new ColumnSchema.ColumnSchemaBuilder("REVERSE_SHORT_FIELD", Type.INT16).key(true).build(),
-        new ColumnSchema.ColumnSchemaBuilder("REVERSE_INT_FIELD", Type.INT32).key(true).build(),
-        new ColumnSchema.ColumnSchemaBuilder("REVERSE_LONG_FIELD", Type.INT64).key(true).build(),
+        new ColumnSchema.ColumnSchemaBuilder("FIELD1", Type.INT32).key(true).build(),
+        new ColumnSchema.ColumnSchemaBuilder("FIELD2", Type.INT32).key(true).build(),
+        new ColumnSchema.ColumnSchemaBuilder("FIELD3", Type.INT32).key(true).build(),
+        new ColumnSchema.ColumnSchemaBuilder("FIELD4", Type.INT64).build(),
         new ColumnSchema.ColumnSchemaBuilder("RESOURCE_TYPE", Type.STRING).build());
 
     Schema schema = new Schema(columns);
@@ -72,23 +72,34 @@ public final class SortedAggregationIT {
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       PreparedStatement stmt = conn
           .prepareStatement("INSERT INTO \"" + descendingSortTableName + "\" " + "VALUES (?,?,?,?,?,?)");
-      insertRow(stmt, (byte) 4, new Short("32"), 100, 1000L, "message-body");
-      insertRow(stmt, (byte) 4, new Short("33"), 101, 1001L, "message-body");
-      insertRow(stmt, (byte) 5, new Short("32"), 100, 50L, "message-body");
-      insertRow(stmt, (byte) 5, new Short("32"), 101, 30L, "message-body");
-      insertRow(stmt, (byte) 6, new Short("32"), 100, 1001L, "user-login");
-      insertRow(stmt, (byte) 6, new Short("33"), 101, 1001L, "user-login");
+      insertRow(stmt, 4, 32, 100, 1000L, "message-body");
+      insertRow(stmt, 4, 32, 101, 1000L, "message-body");
+      insertRow(stmt, 5, 31, 101, 501L, "message-body");
+      insertRow(stmt, 5, 31, 102, 1001L, "message-body");
+      insertRow(stmt, 5, 32, 99, 50L, "message-body");
+      insertRow(stmt, 5, 32, 100, 50L, "message-body");
+      insertRow(stmt, 5, 32, 101, 30L, "message-body");
+      insertRow(stmt, 5, 32, 102, 30L, "message-body");
+      insertRow(stmt, 6, 32, 100, 901L, "user-login");
+      insertRow(stmt, 6, 32, 101, 2001L, "user-login");
+      insertRow(stmt, 6, 33, 101, 10L, "user-login");
+      insertRow(stmt, 6, 33, 102, 20L, "user-login");
       conn.commit();
+
+      // grouped by (FIELD1, FIELD2), SUM(FIELD4) these become
+      // (6,33) 30
+      // (6,32) 2902
+      // (5,32) 160
+      // (5,31) 1502
+      // (4,32) 2000
     }
 
   }
 
   public static class KuduSchemaFactory extends BaseKuduSchemaFactory {
     private static final Map<String, KuduTableMetadata> kuduTableConfigMap = new ImmutableMap.Builder<String, KuduTableMetadata>()
-        .put(descendingSortTableName,
-            new KuduTableMetadata.KuduTableMetadataBuilder().setDescendingOrderedColumnNames(Lists
-                .newArrayList("REVERSE_BYTE_FIELD", "REVERSE_SHORT_FIELD", "REVERSE_INT_FIELD", "REVERSE_LONG_FIELD"))
-                .build())
+        .put(descendingSortTableName, new KuduTableMetadata.KuduTableMetadataBuilder()
+            .setDescendingOrderedColumnNames(Lists.newArrayList("FIELD1", "FIELD2", "FIELD3")).build())
         .build();
 
     // Public singleton, per factory contract.
@@ -99,13 +110,13 @@ public final class SortedAggregationIT {
     }
   }
 
-  private static void insertRow(PreparedStatement stmt, byte byteVal, short shortVal, int intVal, long longVal,
-      String resourceType) throws SQLException {
+  private static void insertRow(PreparedStatement stmt, int val1, int val2, int val3, long val4, String resourceType)
+      throws SQLException {
     stmt.setString(1, JDBCQueryIT.ACCOUNT_SID);
-    stmt.setByte(2, byteVal);
-    stmt.setShort(3, shortVal);
-    stmt.setInt(4, intVal);
-    stmt.setLong(5, longVal);
+    stmt.setInt(2, val1);
+    stmt.setInt(3, val2);
+    stmt.setInt(4, val3);
+    stmt.setLong(5, val4);
     stmt.setString(6, resourceType);
     stmt.execute();
   }
@@ -118,46 +129,136 @@ public final class SortedAggregationIT {
   @Test
   public void aggregateSortedResultsByAccount() throws Exception {
     final String sql = String.format(
-        "SELECT account_sid, sum(reverse_long_field), sum(reverse_int_field) FROM %s WHERE "
+        "SELECT sum(FIELD4) FROM %s WHERE "
             + "resource_type = 'message-body' GROUP BY account_sid ORDER BY account_sid ASC " + "limit 1",
         descendingSortTableName);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
-      ResultSet queryResult = conn.createStatement().executeQuery("SELECT * FROM " + descendingSortTableName);
-      queryResult = conn.createStatement().executeQuery(sql);
+      ResultSet queryResult = conn.createStatement().executeQuery(sql);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);
 
-      final String expectedPlan = "EnumerableAggregate(group=[{0}], EXPR$1=[$SUM0($1)], EXPR$2=[$SUM0($2)])\n"
-          + "  KuduToEnumerableRel\n" + "    KuduSortRel(sort0=[$0], dir0=[ASC], fetch=[1], groupBySorted=[true])\n"
-          + "      KuduProjectRel(ACCOUNT_SID=[$0], REVERSE_LONG_FIELD=[$4], REVERSE_INT_FIELD=[$3])\n"
-          + "        KuduFilterRel(ScanToken 1=[RESOURCE_TYPE EQUAL message-body])\n"
-          + "          KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
+      final String expectedPlan = "EnumerableCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], ACCOUNT_SID=[$t0])\n"
+          + "  EnumerableAggregate(group=[{0}], EXPR$0=[$SUM0($1)])\n" + "    KuduToEnumerableRel\n"
+          + "      KuduSortRel(sort0=[$0], dir0=[ASC], fetch=[1], groupBySorted=[true])\n"
+          + "        KuduProjectRel(ACCOUNT_SID=[$0], FIELD4=[$4])\n"
+          + "          KuduFilterRel(ScanToken 1=[RESOURCE_TYPE EQUAL message-body])\n"
+          + "            KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
 
       assertTrue("Should have results to iterate over", queryResult.next());
       assertTrue(String.format("Plan should contain KuduSortRel. It is\n%s", plan), plan.contains("KuduSortRel"));
       assertTrue(String.format("KuduSortRel should have groupBySorted set to true. It doesn't\n%s", plan),
           plan.contains("groupBySorted=[true]"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 2081, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 3662, queryResult.getLong(1));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
 
   @Test
-  public void aggregateSortedResultsByAccountAndByte() throws Exception {
-    final String sql = String.format(
-        "SELECT account_sid, sum(cast(reverse_long_field as bigint)) \"reverse_long_field\" FROM %s WHERE resource_type = 'message-body' GROUP BY reverse_byte_field, account_sid ORDER BY account_sid ASC, reverse_byte_field DESC limit 2",
+  public void testAggregationSort() throws Exception {
+    String sql = String
+        .format(
+            "SELECT FIELD1, FIELD2, SUM(FIELD4) FROM %s " + "WHERE account_sid = '%s' " + "GROUP BY (FIELD2, FIELD1) "
+                + "ORDER BY FIELD1 DESC, FIELD2 DESC LIMIT 2 OFFSET 1 ",
+            descendingSortTableName, JDBCQueryIT.ACCOUNT_SID);
+
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      ResultSet queryResult = conn.createStatement().executeQuery(sql);
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      String plan = SqlUtil.getExplainPlan(rs);
+
+      String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], FIELD1=[$t1], FIELD2=[$t0], EXPR$2=[$t2])\n"
+          + "  EnumerableAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)])\n" + "    KuduToEnumerableRel\n"
+          + "      KuduSortRel(sort0=[$1], sort1=[$2], dir0=[DESC], dir1=[DESC], offset=[1], fetch=[2], groupBySorted=[true])\n"
+          + "        KuduProjectRel(FIELD2=[$2], FIELD1=[$1], FIELD4=[$4])\n"
+          + "          KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL AC1234567])\n"
+          + "            KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
+
+      assertEquals("Unexpected plan", expectedPlan, plan);
+      assertTrue("Should have results to iterate over", queryResult.next());
+      assertEquals(6, queryResult.getByte(1));
+      assertEquals(32, queryResult.getShort(2));
+      assertEquals("Incorrect aggregated value", 2902, queryResult.getLong(3));
+      assertTrue(queryResult.next());
+      assertEquals(5, queryResult.getByte(1));
+      assertEquals(32, queryResult.getShort(2));
+      assertEquals("Incorrect aggregated value", 160, queryResult.getLong(3));
+      assertFalse("Should not have any more results", queryResult.next());
+
+      // query the next page of results using (5,32) as the page offset
+      sql = String.format(
+          "SELECT FIELD1, FIELD2, SUM(FIELD4) FROM %s " + "WHERE (account_sid = '%s' AND (FIELD1, FIELD2) > (5, 32) ) "
+              + "GROUP BY (FIELD2, FIELD1) ORDER BY FIELD1 DESC, FIELD2 DESC LIMIT 1",
+          descendingSortTableName, JDBCQueryIT.ACCOUNT_SID);
+
+      rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      plan = SqlUtil.getExplainPlan(rs);
+      queryResult = conn.createStatement().executeQuery(sql);
+
+      expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], FIELD1=[$t1], FIELD2=[$t0], EXPR$2=[$t2])\n"
+          + "  EnumerableAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)])\n" + "    KuduToEnumerableRel\n"
+          + "      KuduSortRel(sort0=[$1], sort1=[$2], dir0=[DESC], dir1=[DESC], fetch=[1], groupBySorted=[true])\n"
+          + "        KuduProjectRel(FIELD2=[$2], FIELD1=[$1], FIELD4=[$4])\n"
+          + "          KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL AC1234567, FIELD1 LESS 5], ScanToken 2=[ACCOUNT_SID EQUAL AC1234567, FIELD1 EQUAL 5, FIELD2 LESS 32])\n"
+          + "            KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
+
+      assertEquals("Unexpected plan", expectedPlan, plan);
+      assertTrue("Should have results to iterate over", queryResult.next());
+      assertEquals(5, queryResult.getByte(1));
+      assertEquals(31, queryResult.getShort(2));
+      assertEquals("Incorrect aggregated value", 1502, queryResult.getLong(3));
+      assertFalse("Should not have any more results", queryResult.next());
+    }
+  }
+
+  @Test
+  public void testAggregationSortByPKPrefix() throws Exception {
+    String sql = String.format(
+        "SELECT FIELD1, FIELD2, SUM(FIELD4) " + "FROM %s WHERE account_sid = '%s' GROUP BY (FIELD2, FIELD1) "
+            + "ORDER BY FIELD1 DESC, SUM(FIELD4) DESC LIMIT 2 OFFSET 1",
+        descendingSortTableName, JDBCQueryIT.ACCOUNT_SID);
+
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      ResultSet queryResult = conn.createStatement().executeQuery(sql);
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      String plan = SqlUtil.getExplainPlan(rs);
+
+      String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], FIELD1=[$t1], FIELD2=[$t0], EXPR$2=[$t2])\n"
+          + "  EnumerableLimitSort(sort0=[$1], sort1=[$2], dir0=[DESC], dir1=[DESC], offset=[1], fetch=[2])\n"
+          + "    EnumerableAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)])\n" + "      KuduToEnumerableRel\n"
+          + "        KuduSortRel(sort0=[$1], sort1=[$2], dir0=[DESC], dir1=[DESC], offset=[1], fetch=[2], groupBySorted=[true], sortPrefixColumns=[[1 DESC]])\n"
+          + "          KuduProjectRel(FIELD2=[$2], FIELD1=[$1], FIELD4=[$4])\n"
+          + "            KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL AC1234567])\n"
+          + "              KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
+
+      assertEquals("Unexpected plan", expectedPlan, plan);
+      assertTrue("Should have results to iterate over", queryResult.next());
+      assertEquals(6, queryResult.getByte(1));
+      assertEquals(33, queryResult.getShort(2));
+      assertEquals("Incorrect aggregated value", 30, queryResult.getLong(3));
+      assertTrue(queryResult.next());
+      assertEquals(5, queryResult.getByte(1));
+      assertEquals(31, queryResult.getShort(2));
+      assertEquals("Incorrect aggregated value", 1502, queryResult.getLong(3));
+      assertFalse("Should not have any more results", queryResult.next());
+    }
+  }
+
+  @Test
+  public void aggregateSortedResultsByAccountAndField1() throws Exception {
+    final String sql = String.format("SELECT account_sid, sum(cast(FIELD4 as bigint)) \"FIELD4\" FROM %s WHERE "
+        + "resource_type = 'message-body' GROUP BY FIELD1, account_sid ORDER BY account_sid ASC, FIELD1 DESC limit 2",
         descendingSortTableName);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);
 
-      final String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], ACCOUNT_SID=[$t1], reverse_long_field=[$t2], REVERSE_BYTE_FIELD=[$t0])\n"
-          + "  EnumerableAggregate(group=[{0, 1}], reverse_long_field=[$SUM0($2)])\n" + "    KuduToEnumerableRel\n"
+      final String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], ACCOUNT_SID=[$t1], FIELD4=[$t2], FIELD1=[$t0])\n"
+          + "  EnumerableAggregate(group=[{0, 1}], FIELD4=[$SUM0($2)])\n" + "    KuduToEnumerableRel\n"
           + "      KuduSortRel(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], fetch=[2], groupBySorted=[true])\n"
-          + "        KuduProjectRel(REVERSE_BYTE_FIELD=[$1], ACCOUNT_SID=[$0], $f2=[$4])\n"
+          + "        KuduProjectRel(FIELD1=[$1], ACCOUNT_SID=[$0], $f2=[$4])\n"
           + "          KuduFilterRel(ScanToken 1=[RESOURCE_TYPE EQUAL message-body])\n"
           + "            KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
 
@@ -168,25 +269,25 @@ public final class SortedAggregationIT {
       assertTrue(String.format("KuduSortRel should have groupBySorted set to true. It doesn't\n%s", plan),
           plan.contains("groupBySorted=[true]"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 80, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 1662, queryResult.getLong(2));
       assertTrue("Should have more results", queryResult.next());
-      assertEquals("Incorrect aggregated value", 2001, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 2000, queryResult.getLong(2));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
 
   @Test
   public void aggregateSortedResultsByAccountWrongDirection() throws Exception {
-    final String sql = String.format(
-        "SELECT account_sid, sum(reverse_long_field) FROM %s WHERE resource_type = 'message-body' GROUP BY account_sid ORDER BY account_sid DESC limit 1",
-        descendingSortTableName);
+    final String sql = String
+        .format("SELECT account_sid, sum(FIELD4) FROM %s WHERE resource_type = 'message-body' GROUP BY "
+            + "account_sid ORDER BY account_sid DESC limit 1", descendingSortTableName);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);
       final String expectedPlan = "EnumerableLimitSort(sort0=[$0], dir0=[DESC], fetch=[1])\n"
           + "  EnumerableAggregate(group=[{0}], EXPR$1=[$SUM0($1)])\n" + "    KuduToEnumerableRel\n"
-          + "      KuduProjectRel(ACCOUNT_SID=[$0], REVERSE_LONG_FIELD=[$4])\n"
+          + "      KuduProjectRel(ACCOUNT_SID=[$0], FIELD4=[$4])\n"
           + "        KuduFilterRel(ScanToken 1=[RESOURCE_TYPE EQUAL message-body])\n"
           + "          KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
 
@@ -195,24 +296,24 @@ public final class SortedAggregationIT {
       assertTrue("Should have results to iterate over", queryResult.next());
       assertFalse(String.format("Plan should not contain KuduSortRel. It is\n%s", plan), plan.contains("KuduSortRel"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 2081, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 3662, queryResult.getLong(2));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
 
   @Test
-  public void aggregateSortedResultsByAccountAndByteWithOffset() throws Exception {
+  public void aggregateSortedResultsByAccountAndField1WithOffset() throws Exception {
     final String sql = String.format(
-        "SELECT account_sid, sum(cast(reverse_long_field as bigint)) \"reverse_long_field\" FROM %s WHERE account_sid = '%s' GROUP BY reverse_byte_field, account_sid ORDER BY account_sid ASC, reverse_byte_field DESC limit 1 offset 1",
+        "SELECT account_sid, sum(cast(FIELD4 as bigint)) \"FIELD4\" FROM %s WHERE account_sid = '%s' GROUP BY FIELD1, account_sid ORDER BY account_sid ASC, FIELD1 DESC limit 1 offset 1",
         descendingSortTableName, JDBCQueryIT.ACCOUNT_SID);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);
-      final String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], ACCOUNT_SID=[$t1], reverse_long_field=[$t2], REVERSE_BYTE_FIELD=[$t0])\n"
-          + "  EnumerableAggregate(group=[{0, 1}], reverse_long_field=[$SUM0($2)])\n" + "    KuduToEnumerableRel\n"
+      final String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], ACCOUNT_SID=[$t1], FIELD4=[$t2], FIELD1=[$t0])\n"
+          + "  EnumerableAggregate(group=[{0, 1}], FIELD4=[$SUM0($2)])\n" + "    KuduToEnumerableRel\n"
           + "      KuduSortRel(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], offset=[1], fetch=[1], groupBySorted=[true])\n"
-          + "        KuduProjectRel(REVERSE_BYTE_FIELD=[$1], ACCOUNT_SID=[$0], $f2=[$4])\n"
+          + "        KuduProjectRel(FIELD1=[$1], ACCOUNT_SID=[$0], $f2=[$4])\n"
           + "          KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL AC1234567])\n"
           + "            KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
 
@@ -223,7 +324,7 @@ public final class SortedAggregationIT {
       assertTrue(String.format("KuduSortRel should have groupBySorted set to true. It doesn't\n%s", plan),
           plan.contains("groupBySorted=[true]"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 80, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 1662, queryResult.getLong(2));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
@@ -231,21 +332,21 @@ public final class SortedAggregationIT {
   @Test
   public void aggregatedResultsGroupedByOutOfOrder() throws Exception {
     final String sql = String.format(
-        "SELECT account_sid, sum(reverse_long_field) FROM %s WHERE resource_type = 'message-body'"
-            + " GROUP BY account_sid, reverse_int_field ORDER BY account_sid ASC, " + "reverse_int_field ASC limit 1",
+        "SELECT account_sid, sum(FIELD4) FROM %s WHERE resource_type = 'message-body'"
+            + " GROUP BY account_sid, FIELD1 ORDER BY account_sid ASC, " + "FIELD1 ASC" + " limit 1",
         descendingSortTableName);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);
-      final String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], ACCOUNT_SID=[$t0], EXPR$1=[$t2], REVERSE_INT_FIELD=[$t1])\n"
+      final String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], ACCOUNT_SID=[$t0], EXPR$1=[$t2], FIELD1=[$t1])\n"
           + "  EnumerableLimitSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC], fetch=[1])\n"
           + "    EnumerableAggregate(group=[{0, 1}], EXPR$1=[$SUM0($2)])\n" + "      KuduToEnumerableRel\n"
-          + "        KuduProjectRel(ACCOUNT_SID=[$0], REVERSE_INT_FIELD=[$3], REVERSE_LONG_FIELD=[$4])\n"
-          + "          KuduFilterRel(ScanToken 1=[RESOURCE_TYPE EQUAL message-body])\n"
-          + "            KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
+          + "        KuduSortRel(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC], fetch=[1], groupBySorted=[true], sortPrefixColumns=[[0]])\n"
+          + "          KuduProjectRel(ACCOUNT_SID=[$0], FIELD1=[$1], FIELD4=[$4])\n"
+          + "            KuduFilterRel(ScanToken 1=[RESOURCE_TYPE EQUAL message-body])\n"
+          + "              KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
 
-      assertFalse(String.format("Plan should not contain KuduSortRel. It is\n%s", plan), plan.contains("KuduSortRel"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
     }
   }
@@ -253,7 +354,8 @@ public final class SortedAggregationIT {
   @Test
   public void aggregateSortedResultsByAccountWithLimitOfFour() throws Exception {
     final String sql = String.format(
-        "SELECT account_sid, reverse_byte_field, sum(reverse_long_field), sum(reverse_int_field) FROM %s WHERE account_sid = '%s' GROUP BY account_sid, reverse_byte_field ORDER BY account_sid ASC, reverse_byte_field DESC limit 4",
+        "SELECT account_sid, FIELD1, sum(FIELD3), sum(FIELD4) FROM %s "
+            + "WHERE account_sid = '%s' GROUP BY account_sid, FIELD1 ORDER BY account_sid ASC, FIELD1 DESC limit 4",
         descendingSortTableName, JDBCQueryIT.ACCOUNT_SID);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
@@ -264,7 +366,7 @@ public final class SortedAggregationIT {
       final String expectedPlan = "EnumerableAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)], EXPR$3=[$SUM0($3)])\n"
           + "  KuduToEnumerableRel\n"
           + "    KuduSortRel(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], fetch=[4], groupBySorted=[true])\n"
-          + "      KuduProjectRel(ACCOUNT_SID=[$0], REVERSE_BYTE_FIELD=[$1], REVERSE_LONG_FIELD=[$4], REVERSE_INT_FIELD=[$3])\n"
+          + "      KuduProjectRel(ACCOUNT_SID=[$0], FIELD1=[$1], FIELD3=[$3], FIELD4=[$4])\n"
           + "        KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL AC1234567])\n"
           + "          KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
 
@@ -273,13 +375,13 @@ public final class SortedAggregationIT {
       assertTrue(String.format("KuduSortRel should have groupBySorted set to true. It doesn't\n%s", plan),
           plan.contains("groupBySorted=[true]"));
 
-      assertEquals("Should be grouped second by Byte of 6", (byte) 6, queryResult.getByte(2));
+      assertEquals("Should be grouped second by Byte of 6", 6, queryResult.getByte(2));
       assertTrue("Should have more results", queryResult.next());
 
-      assertEquals("Should be grouped first by Byte of 4", (byte) 5, queryResult.getByte(2));
+      assertEquals("Should be grouped first by Byte of 4", 5, queryResult.getByte(2));
       assertTrue("Should have more results", queryResult.next());
 
-      assertEquals("Should be grouped first by Byte of 4", (byte) 4, queryResult.getByte(2));
+      assertEquals("Should be grouped first by Byte of 4", 4, queryResult.getByte(2));
       assertFalse("Should only have three results", queryResult.next());
 
       assertEquals(String.format("Full SQL plan has changed\n%s", plan), expectedPlan, plan);

--- a/adapter/src/test/java/com/twilio/kudu/sql/SortedAggregationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/SortedAggregationIT.java
@@ -103,7 +103,7 @@ public final class SortedAggregationIT {
       // (5,31) 160
       // (5,30) 1502
       // (4,29) 2000
-      // ACCOUNT_SID1
+      // ACCOUNT_SID2
       // (6,4) 1
       // (6,3) 2
       // (6,2) 3


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Adds a new rule ` KuduAggregationLimitRule` that can be used to limit the number of rows read for a query that orders by a prefix of the primary key columns and other columns and group by only a prefix of the pk columns. 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
