### PR TITLE
log4j1.x removal

### DIFF
--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -70,15 +70,15 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+		<dependency>
+		  <groupId>org.apache.logging.log4j</groupId>
+		  <artifactId>log4j-slf4j-impl</artifactId>
+		  <scope>test</scope>
+		</dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <guava.version>30.1.1-jre</guava.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
+		<log4j.version>2.15.0</log4j.version>
         <mockito.version>3.7.7</mockito.version>
         <jackson.version>2.11.1</jackson.version>
         <spotless.version>2.0.1</spotless.version>
@@ -138,6 +139,21 @@
                 <artifactId>calcite-core</artifactId>
                 <version>${calcite.version}</version>
             </dependency>
+			<!-- This is a dependency of calcite-core that pulls in log4j1.x
+				 This is just copy and pasta from over 8 years ago and at that time log4j 
+				 was assumed for runtime dependency. 
+				 It is *NOT* used during compliation or runtime by this library -->
+			<dependency>
+			  <groupId>com.google.uzaygezen</groupId>
+			  <artifactId>uzaygezen-core</artifactId>
+			  <version>0.2</version>
+			  <exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			  </exclusions>
+			</dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -178,12 +194,12 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <scope>test</scope>
-                <version>${slf4j.version}</version>
-            </dependency>
+			<dependency>
+			  <groupId>org.apache.logging.log4j</groupId>
+			  <artifactId>log4j-slf4j-impl</artifactId>
+			  <version>${log4j.version}</version>
+			  <scope>test</scope>
+			</dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
## Why:
Log4j1.x has been end of life for a long while.

## How:
It was added as a test dependency so we could control the log output
during builds. I lazily added log4j that ships with slf4j -- which is
log4j1.x. After moving to log4j 2.15.0 implementation, we can see that
https://javalibs.com/artifact/com.google.uzaygezen/uzaygezen-core
brings in and old log4j library -- and it brings in an old apache
commons and guava. By specifying log4j as an `exclusion` it will not
be included into the dependencies.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
