### PR TITLE
Dataloader improvements: option to disable cube maintainence, CubeGen…

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ColumnValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ColumnValueGenerator.java
@@ -24,9 +24,10 @@ public abstract class ColumnValueGenerator {
 
   public abstract Object getColumnValue(String columnName);
 
-  /** 
-    * Initialize the {@code ColumnValueGenerator} from JSON or other files. Used as a alternative constructor
-    */
+  /**
+   * Initialize the {@code ColumnValueGenerator} from JSON or other files. Used as
+   * a alternative constructor
+   */
   public abstract void initialize();
 
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ColumnValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ColumnValueGenerator.java
@@ -24,4 +24,9 @@ public abstract class ColumnValueGenerator {
 
   public abstract Object getColumnValue(String columnName);
 
+  // needed because while reading from json the default constructor is used
+  // without member
+  // variables being initialized first
+  public abstract void initialize();
+
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ColumnValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ColumnValueGenerator.java
@@ -24,9 +24,9 @@ public abstract class ColumnValueGenerator {
 
   public abstract Object getColumnValue(String columnName);
 
-  // needed because while reading from json the default constructor is used
-  // without member
-  // variables being initialized first
+  /** 
+    * Initialize the {@code ColumnValueGenerator} from JSON or other files. Used as a alternative constructor
+    */
   public abstract void initialize();
 
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ConstantValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ConstantValueGenerator.java
@@ -21,6 +21,10 @@ public class ConstantValueGenerator<T> extends SingleColumnValueGenerator {
   private ConstantValueGenerator() {
   }
 
+  @Override
+  public void initialize() {
+  }
+
   public ConstantValueGenerator(final T columnValue) {
     this.columnValue = columnValue;
   }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/CubeGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/CubeGenerator.java
@@ -1,0 +1,117 @@
+/* Copyright 2021 Twilio, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twilio.kudu.dataloader.generator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+
+/**
+ * Generate rows using the row counts of a cube grouped by its primary keys.
+ * This is useful to generate data of a non-uniform distribution so that the
+ * rollup of fact rows in a cube can be modelled.
+ */
+public class CubeGenerator extends MultipleColumnValueGenerator {
+
+  // columns that used in the GROUP BY clause of the materialized view
+  public List<String> groupedColumns;
+  // resource that contains counts grouped by the above columns
+  public String groupedColumnCountsResource;
+  // number of unique groups used to generate data for
+  public int numUniqueGroups;
+
+  private int index = -1;
+  private Random rand = new Random();
+  // map from cumulative count to the cube pk grouped column values
+  // When we need to generate column values the chance that a particular row is
+  // choses depends on
+  // its count so we can model a non-uniform distribution
+  private TreeMap<Integer, Object[]> groupedColumnCountMap = new TreeMap<>();
+  // while generating column values we pick a random int from [1,
+  // totalCumulativeCount] and chose
+  // the row that maps to this number
+  private int totalCumulativeCount = 0;
+
+  // map from column name to single column value generator (from Scenario)
+  private Map<String, SingleColumnValueGenerator> columnNameToValueGenerator;
+
+  @Override
+  public List<String> getColumnNames() {
+    return groupedColumns;
+  }
+
+  @Override
+  public void reset() {
+    index = 1 + rand.nextInt(totalCumulativeCount);
+  }
+
+  @Override
+  public Object getColumnValue(String columnName) {
+    int colIndex = groupedColumns.indexOf(columnName);
+    if (colIndex == -1) {
+      throw new RuntimeException("Column not found : " + columnName);
+    }
+    Map.Entry<Integer, Object[]> entry = groupedColumnCountMap.ceilingEntry(index);
+    if (entry != null) {
+      return entry.getValue()[colIndex];
+    } else {
+      throw new RuntimeException("Index not found : " + index + " total count : " + totalCumulativeCount + " "
+          + "min : " + groupedColumnCountMap.firstKey() + " max: " + groupedColumnCountMap.lastKey());
+    }
+  }
+
+  @Override
+  public void initialize() {
+    System.out.println("Reading from " + groupedColumnCountsResource);
+    final InputStream fileStream = this.getClass().getResourceAsStream(groupedColumnCountsResource);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream));
+    try {
+      int numGroupedCounts = Integer.valueOf(reader.readLine());
+      int[] groupedCounts = new int[numGroupedCounts];
+      int index = 0;
+      while (reader.ready()) {
+        String line = reader.readLine();
+        groupedCounts[index++] = Integer.valueOf(line.substring(1, line.length() - 1));
+      }
+      Collections.shuffle(Arrays.asList(groupedCounts));
+      int groupedCountIndex;
+      for (int i = 0; i < numUniqueGroups; ++i) {
+        // handle the case when we want to generate rows for more unique groups than we
+        // have
+        // counts for
+        groupedCountIndex = i % numGroupedCounts;
+        totalCumulativeCount += groupedCounts[groupedCountIndex];
+        Object[] columnValues = new Object[groupedColumns.size()];
+        for (int j = 0; j < groupedColumns.size(); ++j) {
+          columnValues[j] = columnNameToValueGenerator.get(groupedColumns.get(j)).getColumnValue();
+        }
+        groupedColumnCountMap.put(totalCumulativeCount, columnValues);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void setColumnNameToValueGenerator(Map<String, SingleColumnValueGenerator> columnNameToValueGenerator) {
+    this.columnNameToValueGenerator = columnNameToValueGenerator;
+  }
+}

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/CubeGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/CubeGenerator.java
@@ -14,6 +14,10 @@
  */
 package com.twilio.kudu.dataloader.generator;
 
+import com.twilio.kudu.dataloader.DataLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,6 +58,8 @@ public class CubeGenerator extends MultipleColumnValueGenerator {
   // map from column name to single column value generator (from Scenario)
   private Map<String, SingleColumnValueGenerator> columnNameToValueGenerator;
 
+  private static final Logger logger = LoggerFactory.getLogger(CubeGenerator.class);
+
   @Override
   public List<String> getColumnNames() {
     return groupedColumns;
@@ -81,7 +87,7 @@ public class CubeGenerator extends MultipleColumnValueGenerator {
 
   @Override
   public void initialize() {
-    System.out.println("Reading from " + groupedColumnCountsResource);
+    logger.info("Reading from {}", groupedColumnCountsResource);
     final InputStream fileStream = this.getClass().getResourceAsStream(groupedColumnCountsResource);
     BufferedReader reader = new BufferedReader(new InputStreamReader(fileStream));
     try {

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/EnvironmentVariableGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/EnvironmentVariableGenerator.java
@@ -52,4 +52,7 @@ public class EnvironmentVariableGenerator<T> extends SingleColumnValueGenerator<
     return value;
   }
 
+  @Override
+  public void initialize() {
+  }
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/PhoneNumberListGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/PhoneNumberListGenerator.java
@@ -43,11 +43,15 @@ public class PhoneNumberListGenerator extends SingleColumnValueGenerator<String>
   }
 
   @Override
-  public synchronized String getColumnValue() {
+  public String getColumnValue() {
+    return values.get(random.nextInt(values.size()));
+  }
+
+  @Override
+  public void initialize() {
     if (values.isEmpty()) {
       IntStream.range(0, numValues).forEach(index -> values.add(generatePhoneNumber()));
     }
-    return values.get(random.nextInt(values.size()));
   }
 
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/PhoneNumberListGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/PhoneNumberListGenerator.java
@@ -16,12 +16,10 @@ package com.twilio.kudu.dataloader.generator;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 
 public class PhoneNumberListGenerator extends SingleColumnValueGenerator<String> {
-
-  private final Random random = new Random();
 
   public int numValues;
   private List<String> values = new ArrayList<>();
@@ -37,14 +35,14 @@ public class PhoneNumberListGenerator extends SingleColumnValueGenerator<String>
     int leftLimit = 48; // 0
     int rightLimit = 57; // 9
     int targetStringLength = 10;
-    String phoneNumber = random.ints(leftLimit, rightLimit + 1).limit(targetStringLength)
+    String phoneNumber = ThreadLocalRandom.current().ints(leftLimit, rightLimit + 1).limit(targetStringLength)
         .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString();
     return "+1" + phoneNumber;
   }
 
   @Override
   public String getColumnValue() {
-    return values.get(random.nextInt(values.size()));
+    return values.get(ThreadLocalRandom.current().nextInt(values.size()));
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/RandomSidGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/RandomSidGenerator.java
@@ -19,6 +19,8 @@ import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
+import java.util.stream.IntStream;
+
 import org.apache.commons.codec.digest.DigestUtils;
 
 public class RandomSidGenerator extends SingleColumnValueGenerator<String> {
@@ -67,5 +69,9 @@ public class RandomSidGenerator extends SingleColumnValueGenerator<String> {
     final String random = new String(bytes);
 
     return sidPrefix + DigestUtils.md5Hex(ADDR + random + System.currentTimeMillis());
+  }
+
+  @Override
+  public void initialize() {
   }
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/SidListGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/SidListGenerator.java
@@ -16,12 +16,11 @@ package com.twilio.kudu.dataloader.generator;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 
 public class SidListGenerator extends RandomSidGenerator {
 
-  private final Random rand = new Random();
   private final List<String> values = new ArrayList<>();
 
   public int numValues;
@@ -38,7 +37,7 @@ public class SidListGenerator extends RandomSidGenerator {
 
   @Override
   public String getColumnValue() {
-    return values.get(rand.nextInt(values.size()));
+    return values.get(ThreadLocalRandom.current().nextInt(values.size()));
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/SidListGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/SidListGenerator.java
@@ -38,9 +38,13 @@ public class SidListGenerator extends RandomSidGenerator {
 
   @Override
   public String getColumnValue() {
+    return values.get(rand.nextInt(values.size()));
+  }
+
+  @Override
+  public void initialize() {
     if (values.isEmpty()) {
       IntStream.range(0, numValues).forEach(index -> values.add(randomSid()));
     }
-    return values.get(rand.nextInt(values.size()));
   }
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/TimestampGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/TimestampGenerator.java
@@ -28,16 +28,20 @@ public class TimestampGenerator extends UniformLongValueGenerator {
   }
 
   public TimestampGenerator(final long numDaysBefore) {
-    super(System.currentTimeMillis() - numDaysBefore * DateTimeUtils.MILLIS_PER_DAY, System.currentTimeMillis());
+    this.numDaysBefore = numDaysBefore;
   }
 
   @Override
   public synchronized Long getColumnValue() {
+    return super.getColumnValue();
+  }
+
+  @Override
+  public void initialize() {
     if (minValue == 0 && maxValue == 0) {
       minValue = System.currentTimeMillis() - numDaysBefore * DateTimeUtils.MILLIS_PER_DAY;
       maxValue = System.currentTimeMillis();
     }
-    return super.getColumnValue();
   }
 
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/TimestampGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/TimestampGenerator.java
@@ -28,7 +28,7 @@ public class TimestampGenerator extends UniformLongValueGenerator {
   }
 
   public TimestampGenerator(final long numDaysBefore) {
-    this.numDaysBefore = numDaysBefore;
+    super(System.currentTimeMillis() - numDaysBefore * DateTimeUtils.MILLIS_PER_DAY, System.currentTimeMillis());
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformBigDecimalValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformBigDecimalValueGenerator.java
@@ -17,14 +17,13 @@ package com.twilio.kudu.dataloader.generator;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class UniformBigDecimalValueGenerator extends SingleColumnValueGenerator<BigDecimal> {
 
   public int precision = 22;
   public int scale = 6;
   public double maxValue;
-  private final Random random = new Random();
 
   private UniformBigDecimalValueGenerator() {
   }
@@ -38,7 +37,7 @@ public class UniformBigDecimalValueGenerator extends SingleColumnValueGenerator<
    */
   @Override
   public synchronized BigDecimal getColumnValue() {
-    BigDecimal d = new BigDecimal(random.nextDouble() * maxValue, new MathContext(precision));
+    BigDecimal d = new BigDecimal(ThreadLocalRandom.current().nextDouble() * maxValue, new MathContext(precision));
     return d.setScale(scale, RoundingMode.HALF_UP);
   }
 

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformBigDecimalValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformBigDecimalValueGenerator.java
@@ -15,10 +15,14 @@
 package com.twilio.kudu.dataloader.generator;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.Random;
 
 public class UniformBigDecimalValueGenerator extends SingleColumnValueGenerator<BigDecimal> {
 
+  public int precision = 22;
+  public int scale = 6;
   public double maxValue;
   private final Random random = new Random();
 
@@ -29,9 +33,16 @@ public class UniformBigDecimalValueGenerator extends SingleColumnValueGenerator<
     this.maxValue = maxValue;
   }
 
+  /**
+   * Generates a double value between [0, maxValue)
+   */
   @Override
   public synchronized BigDecimal getColumnValue() {
-    return new BigDecimal(String.valueOf(Math.round(random.nextDouble() * maxValue) / maxValue));
+    BigDecimal d = new BigDecimal(random.nextDouble() * maxValue, new MathContext(precision));
+    return d.setScale(scale, RoundingMode.HALF_UP);
   }
 
+  @Override
+  public void initialize() {
+  }
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformIntegerValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformIntegerValueGenerator.java
@@ -30,9 +30,15 @@ public class UniformIntegerValueGenerator extends SingleColumnValueGenerator<Int
     this.maxValue = maxVal;
   }
 
+  /**
+   * Generates a int value between [minValue, maxValue)
+   */
   @Override
-  public synchronized Integer getColumnValue() {
+  public Integer getColumnValue() {
     return minValue + (int) (random.nextDouble() * (maxValue - minValue));
   }
 
+  @Override
+  public void initialize() {
+  }
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformIntegerValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformIntegerValueGenerator.java
@@ -14,11 +14,10 @@
  */
 package com.twilio.kudu.dataloader.generator;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class UniformIntegerValueGenerator extends SingleColumnValueGenerator<Integer> {
 
-  private final Random random = new Random();
   public int minValue;
   public int maxValue;
 
@@ -35,7 +34,7 @@ public class UniformIntegerValueGenerator extends SingleColumnValueGenerator<Int
    */
   @Override
   public Integer getColumnValue() {
-    return minValue + (int) (random.nextDouble() * (maxValue - minValue));
+    return minValue + (int) (ThreadLocalRandom.current().nextDouble() * (maxValue - minValue));
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformLongValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformLongValueGenerator.java
@@ -14,11 +14,10 @@
  */
 package com.twilio.kudu.dataloader.generator;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class UniformLongValueGenerator extends SingleColumnValueGenerator<Long> {
 
-  private final Random rand = new Random();
   public long minValue;
   public long maxValue;
 
@@ -39,7 +38,7 @@ public class UniformLongValueGenerator extends SingleColumnValueGenerator<Long> 
    */
   @Override
   public Long getColumnValue() {
-    return minValue + (long) (rand.nextDouble() * (maxValue - minValue));
+    return minValue + (long) (ThreadLocalRandom.current().nextDouble() * (maxValue - minValue));
   }
 
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformLongValueGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/UniformLongValueGenerator.java
@@ -25,6 +25,10 @@ public class UniformLongValueGenerator extends SingleColumnValueGenerator<Long> 
   protected UniformLongValueGenerator() {
   }
 
+  @Override
+  public void initialize() {
+  }
+
   public UniformLongValueGenerator(final long minVal, final long maxVal) {
     this.minValue = minVal;
     this.maxValue = maxVal;
@@ -34,7 +38,8 @@ public class UniformLongValueGenerator extends SingleColumnValueGenerator<Long> 
    * Generates a long value between [minValue, maxValue)
    */
   @Override
-  public synchronized Long getColumnValue() {
-    return minValue + (long) (rand.nextDouble() * ((maxValue - 1) - minValue));
+  public Long getColumnValue() {
+    return minValue + (long) (rand.nextDouble() * (maxValue - minValue));
   }
+
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ValueListGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ValueListGenerator.java
@@ -34,4 +34,7 @@ public class ValueListGenerator extends SingleColumnValueGenerator<String> {
     return values.get(rand.nextInt(values.size()));
   }
 
+  @Override
+  public void initialize() {
+  }
 }

--- a/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ValueListGenerator.java
+++ b/adapter/src/main/java/com/twilio/kudu/dataloader/generator/ValueListGenerator.java
@@ -15,11 +15,10 @@
 package com.twilio.kudu.dataloader.generator;
 
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class ValueListGenerator extends SingleColumnValueGenerator<String> {
 
-  private final Random rand = new Random();
   public List<String> values;
 
   private ValueListGenerator() {
@@ -31,7 +30,7 @@ public class ValueListGenerator extends SingleColumnValueGenerator<String> {
 
   @Override
   public synchronized String getColumnValue() {
-    return values.get(rand.nextInt(values.size()));
+    return values.get(ThreadLocalRandom.current().nextInt(values.size()));
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTableBuilder.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTableBuilder.java
@@ -32,16 +32,22 @@ public class CalciteKuduTableBuilder {
 
   private CubeTableInfo.EventTimeAggregationType eventTimeAggregationType = null;
 
-  private final boolean enableInserts;
-
-  public CalciteKuduTableBuilder(KuduTable kuduTable, AsyncKuduClient client, boolean enableInserts) {
-    this.kuduTable = kuduTable;
-    this.client = client;
-    this.enableInserts = enableInserts;
-  }
+  private boolean enableInserts;
+  private boolean disableCubeAggregation;
 
   public CalciteKuduTableBuilder(KuduTable kuduTable, AsyncKuduClient client) {
-    this(kuduTable, client, false);
+    this.kuduTable = kuduTable;
+    this.client = client;
+  }
+
+  public CalciteKuduTableBuilder setEnableInserts(boolean enableInserts) {
+    this.enableInserts = enableInserts;
+    return this;
+  }
+
+  public CalciteKuduTableBuilder setDisableCubeAggregation(boolean disableCubeAggregation) {
+    this.disableCubeAggregation = disableCubeAggregation;
+    return this;
   }
 
   public CalciteKuduTableBuilder setDescendingOrderedFieldIndices(List<Integer> descendingOrderedColumnIndices) {
@@ -73,7 +79,7 @@ public class CalciteKuduTableBuilder {
   public CalciteKuduTable build() {
     if (enableInserts) {
       return new CalciteModifiableKuduTable(kuduTable, client, descendingOrderedFieldIndices, timestampColumnIndex,
-          cubeTabes, tableType, eventTimeAggregationType);
+          cubeTabes, tableType, eventTimeAggregationType, disableCubeAggregation);
     }
     return new CalciteKuduTable(kuduTable, client, descendingOrderedFieldIndices, timestampColumnIndex, cubeTabes,
         tableType, eventTimeAggregationType);

--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteModifiableKuduTable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteModifiableKuduTable.java
@@ -35,6 +35,8 @@ public class CalciteModifiableKuduTable extends CalciteKuduTable implements Modi
   // table
   private CubeMaintainer cubeMaintainer;
 
+  private final boolean disableCubeAggregations;
+
   /**
    * Create the {@code CalciteKuduTable} for a physical scan over the
    * provided{@link KuduTable}. {@code KuduTable} must exist and be opened.
@@ -54,9 +56,10 @@ public class CalciteModifiableKuduTable extends CalciteKuduTable implements Modi
   CalciteModifiableKuduTable(final KuduTable kuduTable, final AsyncKuduClient client,
       final List<Integer> descendingOrderColumnIndexes, final int timestampColumnIndex,
       final List<CalciteKuduTable> cubeTables, final TableType tableType,
-      final CubeTableInfo.EventTimeAggregationType eventTimeAggregationType) {
+      final CubeTableInfo.EventTimeAggregationType eventTimeAggregationType, final boolean disableCubeAggregations) {
     super(kuduTable, client, descendingOrderColumnIndexes, timestampColumnIndex, cubeTables, tableType,
         eventTimeAggregationType);
+    this.disableCubeAggregations = disableCubeAggregations;
   }
 
   @Override
@@ -87,4 +90,7 @@ public class CalciteModifiableKuduTable extends CalciteKuduTable implements Modi
     return cubeMaintainer;
   }
 
+  public boolean isDisableCubeAggregations() {
+    return disableCubeAggregations;
+  }
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/schema/KuduSchema.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/schema/KuduSchema.java
@@ -48,9 +48,11 @@ public final class KuduSchema extends AbstractSchema {
   // properties
   public static String KUDU_CONNECTION_STRING = "connect";
   public static String ENABLE_INSERTS_FLAG = "enableInserts";
+  public static String DISABLE_CUBE_AGGREGATIONS = "disableCubeAggregation";
   public static String CREATE_DUMMY_PARTITION_FLAG = "createDummyPartition";
 
   public final boolean enableInserts;
+  public final boolean disableCubeAggregation;
   public final boolean createDummyPartition;
 
   public KuduSchema(final String connectString, final Map<String, KuduTableMetadata> kuduTableMetadataMap,
@@ -58,8 +60,12 @@ public final class KuduSchema extends AbstractSchema {
     this.client = new AsyncKuduClient.AsyncKuduClientBuilder(connectString).build();
     this.kuduTableMetadataMap = kuduTableMetadataMap;
     // We disable inserts by default as this feature has not been thoroughly tested
-
     this.enableInserts = Boolean.valueOf((String) propertyMap.getOrDefault(ENABLE_INSERTS_FLAG, "false"));
+    // If set to true CubeMutationState does not compute aggregations in order to
+    // speed up the
+    // DataLoader (useful only for performance testing)
+    this.disableCubeAggregation = Boolean
+        .valueOf((String) propertyMap.getOrDefault(DISABLE_CUBE_AGGREGATIONS, "false"));
     this.createDummyPartition = Boolean.valueOf((String) propertyMap.getOrDefault(CREATE_DUMMY_PARTITION_FLAG, "true"));
   }
 
@@ -148,7 +154,8 @@ public final class KuduSchema extends AbstractSchema {
       for (CubeTableInfo cubeTableInfo : kuduTableMetadata.getCubeTableInfo()) {
         Optional<KuduTable> cubeTableOptional = openKuduTable(cubeTableInfo.tableName);
         cubeTableOptional.ifPresent(kuduTable -> {
-          final CalciteKuduTableBuilder builder = new CalciteKuduTableBuilder(kuduTable, client, enableInserts)
+          final CalciteKuduTableBuilder builder = new CalciteKuduTableBuilder(kuduTable, client)
+              .setEnableInserts(enableInserts).setDisableCubeAggregation(disableCubeAggregation)
               .setTableType(com.twilio.kudu.sql.TableType.CUBE)
               .setEventTimeAggregationType(cubeTableInfo.eventTimeAggregationType);
           setDescendingFieldIndices(builder, descendingOrderedColumnNames, kuduTable);
@@ -163,7 +170,8 @@ public final class KuduSchema extends AbstractSchema {
       String factTableName = entry.getKey();
       Optional<KuduTable> factTableOptional = openKuduTable(factTableName);
       factTableOptional.ifPresent(kuduTable -> {
-        final CalciteKuduTableBuilder builder = new CalciteKuduTableBuilder(kuduTable, client, enableInserts)
+        final CalciteKuduTableBuilder builder = new CalciteKuduTableBuilder(kuduTable, client)
+            .setEnableInserts(enableInserts).setDisableCubeAggregation(disableCubeAggregation)
             .setTableType(com.twilio.kudu.sql.TableType.FACT).setCubeTables(cubeTableList);
         setDescendingFieldIndices(builder, descendingOrderedColumnNames, kuduTable);
         setTimestampColumnIndex(builder, kuduTableMetadata.getTimestampColumnName(), kuduTable);
@@ -204,8 +212,8 @@ public final class KuduSchema extends AbstractSchema {
 
   private void createCalciteTable(HashMap<String, Table> tableMap, KuduTable kuduTable,
       com.twilio.kudu.sql.TableType tableType) {
-    final CalciteKuduTableBuilder builder = new CalciteKuduTableBuilder(kuduTable, client, enableInserts)
-        .setTableType(tableType);
+    final CalciteKuduTableBuilder builder = new CalciteKuduTableBuilder(kuduTable, client)
+        .setEnableInserts(enableInserts).setTableType(tableType);
     CalciteKuduTable calciteKuduTable = builder.build();
     tableMap.put(kuduTable.getName(), calciteKuduTable);
   }

--- a/adapter/src/test/java/com/twilio/kudu/sql/parser/KuduDDLIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/parser/KuduDDLIT.java
@@ -26,6 +26,7 @@ import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.Partition;
 import org.apache.kudu.client.PartitionSchema;
 import org.apache.kudu.test.KuduTestHarness;
 import org.junit.Assert;

--- a/adapter/src/test/java/com/twilio/kudu/sql/parser/KuduDDLIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/parser/KuduDDLIT.java
@@ -26,7 +26,6 @@ import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
-import org.apache.kudu.client.Partition;
 import org.apache.kudu.client.PartitionSchema;
 import org.apache.kudu.test.KuduTestHarness;
 import org.junit.Assert;


### PR DESCRIPTION
…erator to generate data with non uniform distribution

<!-- Describe your Pull Request -->
Adds an option to disable cube maintenance so that the DataLoader can write data to kudu much faster. Adds an initialize method to the generator so that we don't need to synchronize the getData method for some generators. Adds a new cube generator to generate data using a non uniform distribution so that the cube tables that are populate see realistic reduction in the number of rows.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
