### PR TITLE
Update Log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <guava.version>30.1.1-jre</guava.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
         <mockito.version>3.7.7</mockito.version>
         <jackson.version>2.11.1</jackson.version>
         <spotless.version>2.0.1</spotless.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <guava.version>30.1.1-jre</guava.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
         <mockito.version>3.7.7</mockito.version>
         <jackson.version>2.11.1</jackson.version>
         <spotless.version>2.0.1</spotless.version>
@@ -141,8 +141,8 @@
                 <version>${calcite.version}</version>
             </dependency>
 			<!-- This is a dependency of calcite-core that pulls in log4j1.x
-				 This is just copy and pasta from over 8 years ago and at that time log4j 
-				 was assumed for runtime dependency. 
+				 This is just copy and pasta from over 8 years ago and at that time log4j
+				 was assumed for runtime dependency.
 				 It is *NOT* used during compliation or runtime by this library -->
 			<dependency>
 			  <groupId>com.google.uzaygezen</groupId>


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Updating Log4j version to 2.17.1 because of CVE-2021-44832 vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
