### PR TITLE
Modify KuduAggregationLimitRule to not check that the GROUP BY columns are a prefix of the primary key

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -160,8 +160,8 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
     this.filterFunction = filterFunction;
     this.isSingleObject = isSingleObject;
 
-    // groupFetchLimit calculates it's size based on offset. When offset is present,
-    // it needs to
+    // groupFetchLimit calculates it's size based on offset.
+    // When offset is present, it needs to
     // skip an equivalent number of unique group keys
     if (offset > 0 && limit > 0) {
       groupFetchLimit = limit + offset;

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -165,8 +165,6 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
     // skip an equivalent number of unique group keys
     if (offset > 0 && limit > 0) {
       groupFetchLimit = limit + offset;
-    } else if (offset > 0) {
-      groupFetchLimit = offset;
     } else if (limit > 0) {
       groupFetchLimit = limit;
     } else {

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -27,8 +27,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.Queue;
 
 import org.apache.calcite.linq4j.Enumerator;
@@ -83,6 +87,7 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
   public final Function1<Object, Object> sortedPrefixKeySelector;
   public final long limit;
   public final long offset;
+  public final long groupFetchLimit;
   public final KuduScanStats scanStats;
 
   private final List<List<CalciteKuduPredicate>> predicates;
@@ -154,6 +159,19 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
     this.calciteKuduTable = calciteKuduTable;
     this.filterFunction = filterFunction;
     this.isSingleObject = isSingleObject;
+
+    // groupFetchLimit calculates it's size based on offset. When offset is present,
+    // it needs to
+    // skip an equivalent number of unique group keys
+    if (offset > 0 && limit > 0) {
+      groupFetchLimit = limit + offset;
+    } else if (offset > 0) {
+      groupFetchLimit = offset;
+    } else if (limit > 0) {
+      groupFetchLimit = limit;
+    } else {
+      groupFetchLimit = Long.MAX_VALUE;
+    }
   }
 
   @VisibleForTesting
@@ -278,9 +296,23 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
   public Enumerator<Object> sortedEnumerator(final List<AsyncKuduScanner> scanners,
       final List<Enumerator<CalciteRow>> subEnumerables) {
 
+    class EnumerableComparator implements Comparator<Enumerator<CalciteRow>> {
+      @Override
+      public int compare(Enumerator<CalciteRow> o1, Enumerator<CalciteRow> o2) {
+        // assumes that moveNext has been called on the enumerators and that they havent
+        // reached
+        // the end of their respective collections
+        return o1.current().compareTo(o2.current());
+      }
+    }
+
     return new Enumerator<Object>() {
       private Object next = null;
-      private List<Boolean> enumerablesWithRows = new ArrayList<>(subEnumerables.size());
+      // use a min heap to keep track of the smallest record from each of the
+      // subEnumerables
+      // (which returned rows sorted)
+      private PriorityQueue<Enumerator<CalciteRow>> minQueue = new PriorityQueue<>(subEnumerables.size(),
+          new EnumerableComparator());
       private int totalMoves = 0;
 
       private void moveToOffset() {
@@ -299,46 +331,29 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           return false;
         }
 
-        if (enumerablesWithRows.isEmpty()) {
+        if (minQueue.isEmpty()) {
           for (int idx = 0; idx < subEnumerables.size(); idx++) {
-            enumerablesWithRows.add(subEnumerables.get(idx).moveNext());
+            if (subEnumerables.get(idx).moveNext()) {
+              minQueue.add(subEnumerables.get(idx));
+            }
           }
           moveToOffset();
-          logger.debug("Setup scanners {}", enumerablesWithRows);
+          logger.trace("Setup enumerables for {} scanners", subEnumerables.size());
         }
-        CalciteRow smallest = null;
-        int chosenEnumerable = -1;
-        for (int idx = 0; idx < subEnumerables.size(); idx++) {
-          if (enumerablesWithRows.get(idx)) {
-            final CalciteRow enumerablesNext = subEnumerables.get(idx).current();
-            if (smallest == null) {
-              logger.trace("smallest isn't set setting to {}", enumerablesNext.getRowData());
-              smallest = enumerablesNext;
-              chosenEnumerable = idx;
-            } else if (enumerablesNext.compareTo(smallest) < 0) {
-              logger.trace("{} is smaller then {}", enumerablesNext.getRowData(), smallest.getRowData());
-              smallest = enumerablesNext;
-              chosenEnumerable = idx;
-            } else {
-              logger.trace("{} is larger then {}", enumerablesNext.getRowData(), smallest.getRowData());
-            }
-          } else {
-            logger.trace("{} index doesn't have next", idx);
-          }
-        }
-        if (smallest == null) {
+        if (minQueue.isEmpty()) {
           return false;
         }
+        Enumerator<CalciteRow> smallestEnumerator = minQueue.poll();
         // Indicates this is the first move.
         if (next == null) {
           scanStats.setTimeToFirstRowMs();
         }
-        next = smallest.getRowData();
+        next = smallestEnumerator.current().getRowData();
 
-        // Move the chosen one forward. The others have their smallest
-        // already in the front of their queues.
-        logger.trace("Chosen idx {} to move next", chosenEnumerable);
-        enumerablesWithRows.set(chosenEnumerable, subEnumerables.get(chosenEnumerable).moveNext());
+        // Move the chosen one forward.
+        if (smallestEnumerator.moveNext()) {
+          minQueue.add(smallestEnumerator);
+        }
         totalMoves++;
         boolean limitReached = checkLimitReached(totalMoves);
 
@@ -407,10 +422,96 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
     return unsortedEnumerator(scanners, messages);
   }
 
+  // Copied from Calcite as that class is private
+  /**
+   * Reads a populated map, applying a selector function.
+   *
+   * @param <TResult>     result type
+   * @param <TKey>        key type
+   * @param <TAccumulate> accumulator type
+   */
+  private static class LookupResultEnumerable<TResult, TKey, TAccumulate> extends AbstractEnumerable2<TResult> {
+    private final Map<TKey, TAccumulate> map;
+    private final Function2<TKey, TAccumulate, TResult> resultSelector;
+
+    LookupResultEnumerable(Map<TKey, TAccumulate> map, Function2<TKey, TAccumulate, TResult> resultSelector) {
+      this.map = map;
+      this.resultSelector = resultSelector;
+    }
+
+    @Override
+    public Iterator<TResult> iterator() {
+      final Iterator<Map.Entry<TKey, TAccumulate>> iterator = map.entrySet().iterator();
+      return new Iterator<TResult>() {
+        @Override
+        public boolean hasNext() {
+          return iterator.hasNext();
+        }
+
+        @Override
+        public TResult next() {
+          final Map.Entry<TKey, TAccumulate> entry = iterator.next();
+          return resultSelector.apply(entry.getKey(), entry.getValue());
+        }
+
+        @Override
+        public void remove() {
+          throw new UnsupportedOperationException();
+        }
+      };
+    }
+  }
+
+  // modified from Calcite to stop reading rows once we have enough unique groups
+  private <TSource, TKey, TAccumulate, TResult> Enumerable<TResult> groupBy_(final Map<TKey, TAccumulate> map,
+      Enumerable<TSource> enumerable, Function1<TSource, TKey> keySelector,
+      Function0<TAccumulate> accumulatorInitializer, Function2<TAccumulate, TSource, TAccumulate> accumulatorAdder,
+      final Function2<TKey, TAccumulate, TResult> resultSelector) {
+    Object lastSortedKey = null;
+    try (Enumerator<TSource> os = enumerable.enumerator()) {
+      while (os.moveNext()) {
+        TSource o = os.current();
+        TKey key = keySelector.apply(o);
+        @SuppressWarnings("argument.type.incompatible")
+        TAccumulate accumulator = map.get(key);
+        final Object sortedKey = sortedPrefixKeySelector.apply(o);
+        // If sortedPrefixKeySelector is not null, we can only stop reading rows when
+        // the sorted
+        // key prefix changes and we have enough unique groups since the rows have to be
+        // sorted
+        // on the client we have to read all the rows that have the same sorted primary
+        // key prefix)
+        if (lastSortedKey != null && !sortedKey.equals(lastSortedKey) && map.size() > groupFetchLimit) {
+          logger.debug("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}", sortedKey, lastSortedKey,
+              map.size(), groupFetchLimit);
+          break;
+        }
+        lastSortedKey = sortedKey;
+        logger.debug("sortedKey {} uniqueGroupCount{}", sortedKey, map.size());
+        if (accumulator == null) {
+          accumulator = accumulatorInitializer.apply();
+          accumulator = accumulatorAdder.apply(accumulator, o);
+          map.put(key, accumulator);
+        } else {
+          TAccumulate accumulator0 = accumulator;
+          accumulator = accumulatorAdder.apply(accumulator, o);
+          if (accumulator != accumulator0) {
+            map.put(key, accumulator);
+          }
+        }
+      }
+    }
+    return new LookupResultEnumerable<>(map, resultSelector);
+  }
+
   @Override
   public <TKey, TAccumulate, TResult> Enumerable<TResult> groupBy(Function1<Object, TKey> keySelector,
       Function0<TAccumulate> accumulatorInitializer, Function2<TAccumulate, Object, TAccumulate> accumulatorAdder,
       Function2<TKey, TAccumulate, TResult> resultSelector) {
+    if (sortedPrefixKeySelector != null) {
+      return groupBy_(new HashMap<>(), getThis(), keySelector, accumulatorInitializer, accumulatorAdder,
+          resultSelector);
+    }
     // When Grouping rows but the aggregation is not sorted by primary key direction
     // or there is no
     // limit to the grouping, read every single matching row for this query.
@@ -422,44 +523,13 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
 
     int uniqueGroupCount = 0;
     TKey lastKey = null;
-    Object lastSortedKey = null;
-
-    // groupFetchLimit calculates it's size based on offset. When offset is present,
-    // it needs to
-    // skip an equivalent number of unique group keys
-    long groupFetchLimit = Long.MAX_VALUE;
-    if (offset > 0 && limit > 0) {
-      groupFetchLimit = limit + offset;
-    } else if (offset > 0) {
-      groupFetchLimit = offset;
-    } else if (limit > 0) {
-      groupFetchLimit = limit;
-    }
     final Queue<TResult> sortedResults = new LinkedList<TResult>();
-
     try (Enumerator<Object> objectEnumeration = getThis().enumerator()) {
       TAccumulate accumulator = null;
 
       while (objectEnumeration.moveNext()) {
         Object o = objectEnumeration.current();
         final TKey key = keySelector.apply(o);
-
-        if (sortedPrefixKeySelector != null) {
-          final Object sortedKey = sortedPrefixKeySelector.apply(o);
-          // If sortedPrefixKeySelector is not null, we can only stop reading rows when
-          // the
-          // sorted key prefix changes and we have enough unique groups since the rows
-          // have to be
-          // sorted on the client we have to read all the rows that have the same sorted
-          // primary key prefix)
-          if (lastSortedKey != null && !sortedKey.equals(lastSortedKey) && uniqueGroupCount > groupFetchLimit) {
-            logger.debug("sortedKey {} lastSortedKey {} uniqueGroupCount {} groupFetchLimit {}", sortedKey,
-                lastSortedKey, uniqueGroupCount, groupFetchLimit);
-            break;
-          }
-          lastSortedKey = sortedKey;
-          logger.debug("sortedKey {} uniqueGroupCount{}", sortedKey, uniqueGroupCount);
-        }
 
         // If there hasn't been a key yet or if there is a new key
         if (lastKey == null || !key.equals(lastKey)) {
@@ -471,21 +541,16 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
           }
           uniqueGroupCount++;
 
-          // sortedPrefixKeySelector is null means we don't have to sort results on the
-          // client
           // When we have seen limit + 1 unique group by keys, exit.
           // or in the case of an offset, limit + offset + 1 unique group by keys.
-          if (sortedPrefixKeySelector == null && uniqueGroupCount > groupFetchLimit) {
+          if (uniqueGroupCount > groupFetchLimit) {
             break;
           }
           logger.debug("key {} uniqueGroupCount{}", key, uniqueGroupCount);
           lastKey = key;
         }
 
-        // We can only skip rows if we don't need to sort the returned rows on the
-        // client
-        // (sortedPrefixKeySelector is null)
-        if (sortedPrefixKeySelector == null && offset > 0 && uniqueGroupCount <= offset) {
+        if (offset > 0 && uniqueGroupCount <= offset) {
           // We are still skipping group by keys.
           continue;
         }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -52,10 +52,16 @@ import java.util.stream.Collectors;
 
 /**
  * Rule to match a limit over a sort over aggregation. There must be a common
- * prefix between the sort columns and the primary key columns of the table. If
- * a table has three columns A, B and C with a PK(A, B) this rule can be applied
- * if sorting by (A, SUM(C)) and grouping by (A, B). This rule limits the number
- * of rows read from kudu, but rows still need to be sorted on the client.
+ * prefix between the sort columns and the primary key columns of the table.
+ *
+ * If a table has three columns A, B and C with a PK(A, B) this rule can be
+ * applied if sorting by (A, SUM(C)) and grouping by (A, B) with a limit. For
+ * eg: (A,B,C) (1, 1, 4), (1, 2, 2), (2, 1, 1). If we query with a limit of 2,
+ * then we can stop reading rows when we process the 3rd row as we will have 2
+ * groups (1,1) and (1,2).
+ * 
+ * This rule limits the number of rows read from kudu, but rows still need to be
+ * sorted on the client.
  */
 public class KuduAggregationLimitRule extends RelOptRule {
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -52,10 +52,10 @@ import java.util.stream.Collectors;
 
 /**
  * Rule to match a limit over a sort over aggregation. There must be a common
- * prefix between the sort columns and the primary key columns of the table. The
- * aggregation columns should be a a prefix of the primary key columns. For eg
- * if a table has three columns A, B and C with a PK(A, B) this rule can be
- * applied if sorting by (A, C) and grouping by (A, B).
+ * prefix between the sort columns and the primary key columns of the table. If
+ * a table has three columns A, B and C with a PK(A, B) this rule can be applied
+ * if sorting by (A, SUM(C)) and grouping by (A, B). This rule limits the number
+ * of rows read from kudu, but rows still need to be sorted on the client.
  */
 public class KuduAggregationLimitRule extends RelOptRule {
 
@@ -98,28 +98,14 @@ public class KuduAggregationLimitRule extends RelOptRule {
         .map(groupedOrdinal -> ((RexInputRef) project.getProjects().get(groupedOrdinal)).getIndex())
         // sort so that we can check if the group by columns match a prefix
         .sorted().collect(Collectors.toList());
-    for (Integer remappedGroupOrdinal : remappedGroupOrdinals) {
-      // the group by columns must be a prefix of the primary key columns
-      if (remappedGroupOrdinal != pkColumnIndex) {
-        // This field is not in the primary key columns. If there is a condition lets
-        // see if it is there
-        final RexBuilder rexBuilder = filter.getCluster().getRexBuilder();
-        final RexNode originalCondition = RexUtil.expandSearch(rexBuilder, null, filter.getCondition());
-        while (pkColumnIndex < remappedGroupOrdinal) {
-          final KuduSortRule.KuduFilterVisitor visitor = new KuduSortRule.KuduFilterVisitor(pkColumnIndex);
-          final Boolean foundFieldInCondition = originalCondition.accept(visitor);
-          if (foundFieldInCondition.equals(Boolean.FALSE)) {
-            return;
-          }
-          pkColumnIndex++;
-        }
-      }
-      pkColumnIndex++;
-    }
 
     final Map<Integer, Integer> remappingOrdinals = new HashMap<>();
     for (RelFieldCollation fieldCollation : originalSort.getCollation().getFieldCollations()) {
       int projectOrdinal = fieldCollation.getFieldIndex();
+      // return if not sorting by a projected column
+      if (projectOrdinal > project.getProjects().size() - 1) {
+        return;
+      }
       int kuduColumnIndex = ((RexInputRef) project.getProjects().get(projectOrdinal)).getIndex();
       remappingOrdinals.put(fieldCollation.getFieldIndex(), kuduColumnIndex);
     }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
@@ -48,7 +48,7 @@ import java.util.Optional;
 /**
  * Rule that matches a sort over an aggregation with both sort and aggregation
  * using the same columns. The columns must be a prefix of the primary key of
- * the table.
+ * the table. This rule eliminates the need for sorting on the client.
  */
 public class KuduSortedAggregationRule extends KuduSortRule {
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/schema/KuduSchema.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/schema/KuduSchema.java
@@ -101,14 +101,6 @@ public final class KuduSchema extends AbstractSchema {
           factToCubeListMap.put(factTableName, new ArrayList<>());
         }
         factToCubeListMap.get(factTableName).add(cubeTableInfo);
-        logger.info("Added cubetable info to factToCubeListMap " + "Cubetablename: " + cubeTableInfo.tableName
-            + "EventAggregationType: " + cubeTableInfo.eventTimeAggregationType + "FactTableName: " + factTableName);
-
-        logger.error("Added cubetable info to factToCubeListMap " + "Cubetablename: " + cubeTableInfo.tableName
-            + "EventAggregationType: " + cubeTableInfo.eventTimeAggregationType + "FactTableName: " + factTableName);
-
-        System.out.println("Added cubetable info to factToCubeListMap " + "Cubetablename: " + cubeTableInfo.tableName
-            + "EventAggregationType: " + cubeTableInfo.eventTimeAggregationType + "FactTableName: " + factTableName);
       }
     }
 
@@ -121,9 +113,6 @@ public final class KuduSchema extends AbstractSchema {
         try {
           KuduTable kuduTable = this.client.openTable(tableName).join();
           for (ColumnSchema columnSchema : kuduTable.getSchema().getColumns()) {
-            logger.info("populating kudutableMetadatMap for fact tables created with DDLS:  " + columnSchema.getName());
-            logger
-                .error("populating kudutableMetadatMap for fact tables created with DDLS:  " + columnSchema.getName());
             String comment = columnSchema.getComment();
             JSONObject jsonObject = getJsonObject(comment);
             if (!comment.isEmpty() && jsonObject != null) {

--- a/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/JDBCQueryIT.java
@@ -349,9 +349,10 @@ public final class JDBCQueryIT {
       // KuduAggregationLimitRule
       String expectedPlan = "EnumerableLimitSort(sort0=[$0], dir0=[ASC], fetch=[51])\n"
           + "  EnumerableAggregate(group=[{0, 1}], EXPR$2=[COUNT()])\n" + "    KuduToEnumerableRel\n"
-          + "      KuduProjectRel(ACCOUNT_SID=[$0], ERROR_CODE=[$5])\n"
-          + "        KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567])\n"
-          + "          KuduQuery(table=[[kudu, ReportCenter.DeliveredMessages]])\n";
+          + "      KuduSortRel(sort0=[$0], dir0=[ASC], fetch=[51], groupBySorted=[true], sortPkPrefixColumns=[[0]])\n"
+          + "        KuduProjectRel(ACCOUNT_SID=[$0], ERROR_CODE=[$5])\n"
+          + "          KuduFilterRel(ScanToken 1=[account_sid EQUAL AC1234567])\n"
+          + "            KuduQuery(table=[[kudu, ReportCenter.DeliveredMessages]])\n";
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
       String plan = SqlUtil.getExplainPlan(rs);
       assertEquals("Unexpected plan ", expectedPlan, plan);

--- a/adapter/src/test/java/com/twilio/kudu/sql/SortedAggregationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/SortedAggregationIT.java
@@ -77,14 +77,16 @@ public final class SortedAggregationIT {
       PreparedStatement stmt = conn
           .prepareStatement("INSERT INTO \"" + descendingSortTableName + "\" " + "VALUES (?,?,?,?,?,?)");
       // rows for ACCOUNT_SID1
+      insertRow(stmt, 3, 29, 100, 1000L, "message-body", ACCOUNT_SID1);
+      insertRow(stmt, 3, 29, 101, 1000L, "message-body", ACCOUNT_SID1);
       insertRow(stmt, 4, 29, 100, 1000L, "message-body", ACCOUNT_SID1);
       insertRow(stmt, 4, 29, 101, 1000L, "message-body", ACCOUNT_SID1);
       insertRow(stmt, 5, 30, 101, 501L, "message-body", ACCOUNT_SID1);
       insertRow(stmt, 5, 30, 102, 1001L, "message-body", ACCOUNT_SID1);
       insertRow(stmt, 5, 31, 99, 50L, "message-body", ACCOUNT_SID1);
       insertRow(stmt, 5, 31, 100, 50L, "message-body", ACCOUNT_SID1);
-      insertRow(stmt, 5, 31, 101, 30L, "message-body", ACCOUNT_SID1);
-      insertRow(stmt, 5, 31, 102, 30L, "message-body", ACCOUNT_SID1);
+      insertRow(stmt, 5, 31, 101, 30L, "user-login", ACCOUNT_SID1);
+      insertRow(stmt, 5, 31, 102, 30L, "user-login", ACCOUNT_SID1);
       insertRow(stmt, 6, 32, 100, 901L, "user-login", ACCOUNT_SID1);
       insertRow(stmt, 6, 32, 101, 2001L, "user-login", ACCOUNT_SID1);
       insertRow(stmt, 6, 33, 101, 10L, "user-login", ACCOUNT_SID1);
@@ -103,11 +105,22 @@ public final class SortedAggregationIT {
       // (5,31) 160
       // (5,30) 1502
       // (4,29) 2000
+      // (3,29) 2000
       // ACCOUNT_SID2
       // (6,4) 1
       // (6,3) 2
       // (6,2) 3
       // (6,1) 4
+
+      // grouped by (FIELD1, RESOURCE), SUM(FIELD4) these become
+      // ACCOUNT_SID1
+      // (6, "user-login") 2932
+      // (5, "message-body") 1602
+      // (5, "user-login") 60
+      // (4, "message-body") 2000
+      // (3, "message-body") 2000
+      // ACCOUNT_SID2
+      // (6, "user-login") 10
     }
 
   }
@@ -166,7 +179,7 @@ public final class SortedAggregationIT {
       assertTrue(String.format("KuduSortRel should have groupBySorted set to true. It doesn't\n%s", plan),
           plan.contains("groupBySorted=[true]"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 3662, queryResult.getLong(1));
+      assertEquals("Incorrect aggregated value", 5602, queryResult.getLong(1));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
@@ -227,7 +240,7 @@ public final class SortedAggregationIT {
   }
 
   @Test
-  public void testAggregationSortByPKPrefix() throws Exception {
+  public void testAggregationSortAndGroupByPKPrefix() throws Exception {
     String sql = String.format(
         "SELECT FIELD1, FIELD2, SUM(FIELD4) " + "FROM %s WHERE account_sid = '%s' GROUP BY "
             + "(FIELD2, FIELD1) ORDER BY FIELD1 DESC, SUM(FIELD4) DESC LIMIT 2 OFFSET 1",
@@ -266,6 +279,48 @@ public final class SortedAggregationIT {
       assertEquals(6, queryResult.getByte(1));
       assertEquals(1, queryResult.getShort(2));
       assertEquals("Incorrect aggregated value", 4, queryResult.getLong(3));
+      assertFalse("Should not have any more results", queryResult.next());
+    }
+  }
+
+  @Test
+  public void testAggregationSortByPKPrefix() throws Exception {
+    String sql = String.format(
+        "SELECT FIELD1, RESOURCE_TYPE, SUM(FIELD4) FROM %s WHERE account_sid = '%s' GROUP BY "
+            + "(RESOURCE_TYPE, FIELD1) ORDER BY FIELD1 DESC, RESOURCE_TYPE LIMIT 2 OFFSET 1",
+        descendingSortTableName, ACCOUNT_SID1);
+
+    try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
+      ResultSet queryResult = conn.createStatement().executeQuery(sql);
+      ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
+      String plan = SqlUtil.getExplainPlan(rs);
+
+      String expectedPlan = "EnumerableCalc(expr#0..2=[{inputs}], FIELD1=[$t1], RESOURCE_TYPE=[$t0], EXPR$2=[$t2])\n"
+          + "  EnumerableLimitSort(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC], offset=[1], fetch=[2])\n"
+          + "    EnumerableAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)])\n" + "      KuduToEnumerableRel\n"
+          + "        KuduSortRel(sort0=[$1], sort1=[$0], dir0=[DESC], dir1=[ASC], offset=[1], fetch=[2], groupBySorted=[true], sortPkPrefixColumns=[[1 DESC]])\n"
+          + "          KuduProjectRel(RESOURCE_TYPE=[$5], FIELD1=[$1], FIELD4=[$4])\n"
+          + "            KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL ACCOUNT1])\n"
+          + "              KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
+
+      assertEquals("Unexpected plan", expectedPlan, plan);
+      assertTrue("Should have results to iterate over", queryResult.next());
+      assertEquals(5, queryResult.getByte(1));
+      assertEquals("message-body", queryResult.getString(2));
+      assertEquals("Incorrect aggregated value", 1602, queryResult.getLong(3));
+      assertTrue("Should have results to iterate over", queryResult.next());
+      assertEquals(5, queryResult.getByte(1));
+      assertEquals("user-login", queryResult.getString(2));
+      assertEquals("Incorrect aggregated value", 60, queryResult.getLong(3));
+      assertFalse("Should not have any more results", queryResult.next());
+
+      sql = String.format("SELECT FIELD1, RESOURCE_TYPE, SUM(FIELD4) FROM %s WHERE account_sid = '%s' GROUP BY "
+          + "(RESOURCE_TYPE, FIELD1) ORDER BY FIELD1 DESC, RESOURCE_TYPE", descendingSortTableName, ACCOUNT_SID2);
+      queryResult = conn.createStatement().executeQuery(sql);
+      assertTrue("Should have results to iterate over", queryResult.next());
+      assertEquals(6, queryResult.getByte(1));
+      assertEquals("user-login", queryResult.getString(2));
+      assertEquals("Incorrect aggregated value", 10, queryResult.getLong(3));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
@@ -318,7 +373,7 @@ public final class SortedAggregationIT {
       assertTrue(String.format("KuduSortRel should have groupBySorted set to true. It doesn't\n%s", plan),
           plan.contains("groupBySorted=[true]"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 1662, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 1602, queryResult.getLong(2));
       assertTrue("Should have more results", queryResult.next());
       assertEquals("Incorrect aggregated value", 2000, queryResult.getLong(2));
       assertFalse("Should not have any more results", queryResult.next());
@@ -345,7 +400,7 @@ public final class SortedAggregationIT {
       assertTrue("Should have results to iterate over", queryResult.next());
       assertFalse(String.format("Plan should not contain KuduSortRel. It is\n%s", plan), plan.contains("KuduSortRel"));
       assertEquals("Full SQL plan has changed\n", expectedPlan, plan);
-      assertEquals("Incorrect aggregated value", 3662, queryResult.getLong(2));
+      assertEquals("Incorrect aggregated value", 5602, queryResult.getLong(2));
       assertFalse("Should not have any more results", queryResult.next());
     }
   }
@@ -401,10 +456,10 @@ public final class SortedAggregationIT {
   }
 
   @Test
-  public void aggregateSortedResultsByAccountWithLimitOfFour() throws Exception {
+  public void aggregateSortedResultsByAccountWithLimitOfFive() throws Exception {
     final String sql = String.format(
         "SELECT account_sid, FIELD1, sum(FIELD3), sum(FIELD4) FROM %s "
-            + "WHERE account_sid = '%s' GROUP BY account_sid, FIELD1 ORDER BY account_sid ASC, FIELD1 DESC limit 4",
+            + "WHERE account_sid = '%s' GROUP BY account_sid, FIELD1 ORDER BY account_sid ASC, FIELD1 DESC limit 5",
         descendingSortTableName, ACCOUNT_SID1);
 
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
@@ -414,7 +469,7 @@ public final class SortedAggregationIT {
 
       final String expectedPlan = "EnumerableAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)], EXPR$3=[$SUM0($3)])\n"
           + "  KuduToEnumerableRel\n"
-          + "    KuduSortRel(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], fetch=[4], groupBySorted=[true])\n"
+          + "    KuduSortRel(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[DESC], fetch=[5], groupBySorted=[true])\n"
           + "      KuduProjectRel(ACCOUNT_SID=[$0], FIELD1=[$1], FIELD3=[$3], FIELD4=[$4])\n"
           + "        KuduFilterRel(ScanToken 1=[ACCOUNT_SID EQUAL ACCOUNT1])\n"
           + "          KuduQuery(table=[[kudu, SortedAggregationIT]])\n";
@@ -431,7 +486,10 @@ public final class SortedAggregationIT {
       assertTrue("Should have more results", queryResult.next());
 
       assertEquals("Should be grouped first by Byte of 4", 4, queryResult.getByte(2));
-      assertFalse("Should only have three results", queryResult.next());
+      assertTrue("Should have more results", queryResult.next());
+
+      assertEquals("Should be grouped first by Byte of 4", 3, queryResult.getByte(2));
+      assertFalse("Should only have four results", queryResult.next());
 
       assertEquals(String.format("Full SQL plan has changed\n%s", plan), expectedPlan, plan);
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

Modify KuduAggregationLimitRule to not check that the GROUP BY columns are a prefix of the primary key so that we limit the amount of rows that have to be read from kudu if we sort by a prefix of the primary key. 

This PR also modified sortedEnumerator to use a minHeap to keep track of the smallest element from each of the scanners used to query kudu which speeds us queries.

