### PR TITLE
Set commons-io to 2.11.0 to address CVE-2021-29425

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,8 @@
     </modules>
 
     <properties>
+	  <!-- When updating check if CALCITE-5025 is resolved and if it is removed 
+		   commons-io:commons-io from dependency managment section -->
         <calcite.version>1.26.0</calcite.version>
         <kudu.version>1.15.0</kudu.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -157,6 +159,14 @@
                 </exclusion>
               </exclusions>
             </dependency>
+
+			<!-- This is a dependency of calcite-core and has a medium vuln. Can
+				 be removed when CALCITE-5025 is fixed -->
+			<dependency>
+			  <groupId>commons-io</groupId>
+			  <artifactId>commons-io</artifactId>
+			  <version>2.11.0</version>
+			</dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Why:
`calcite-core` pulls in 2.4 which was released in 2012. Versions less
than 2.7 allow strings to traverse into the parent directories.

https://security.snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109

## How:
Adds a comment around the `calcite.version` property to help the
engineer check the calcite bug to see if it is addressed.

It adds `commons-io` dependency into the `dependencyManagement`
section so that it is used whenever `commons-io` is pulled into a
module.

We can see this works:
```
mvn dependency:tree | grep commons-io
[INFO] |  +- commons-io:commons-io:jar:2.11.0:runtime
```

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
