### PR TITLE
Add snapshotDiffFromCurrentTime as parameter to KuduQuery method

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
@@ -205,41 +205,45 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
    * to return in the response and finally {@code limit} is used to limit the
    * results that come back.
    *
-   * @param predicates              each member in the first list represents a
-   *                                single scan.
-   * @param columnIndices           the fields ordinals to select out of Kudu
-   * @param limit                   process the results until limit is reached. If
-   *                                less then 0, no limit
-   * @param offset                  skip offset number of rows before returning
-   *                                results
-   * @param sorted                  whether to return rows in sorted order
-   * @param groupByLimited          indicates if the groupBy method should be
-   *                                counting unique keys
-   * @param scanStats               scan stats collector
-   * @param cancelFlag              flag to indicate the query has been canceled
-   * @param projection              function to map the
-   *                                {@link org.apache.kudu.client.RowResult} to
-   *                                calcite object
-   * @param filterFunction          predicate to apply to
-   *                                {@link org.apache.kudu.client.RowResult}
-   * @param isSingleObject          boolean indicating if the projection returns
-   *                                Object[] or Object
-   * @param sortedPrefixKeySelector the subset of columns being sorted by that are
-   *                                a prefix of the primary key of the table, or
-   *                                an empty list if the group by and order by
-   *                                columns are the same
-   * @param sortPkColumnNames       the names of the primary key columns that are
-   *                                present in the ORDER BY clause
+   * @param predicates                  each member in the first list represents a
+   *                                    single scan.
+   * @param columnIndices               the fields ordinals to select out of Kudu
+   * @param limit                       process the results until limit is
+   *                                    reached. If less then 0, no limit
+   * @param offset                      skip offset number of rows before
+   *                                    returning results
+   * @param snapshotDiffFromCurrentTime time in milliseconds before current time
+   *                                    to read table state at
+   * @param sorted                      whether to return rows in sorted order
+   * @param groupByLimited              indicates if the groupBy method should be
+   *                                    counting unique keys
+   * @param scanStats                   scan stats collector
+   * @param cancelFlag                  flag to indicate the query has been
+   *                                    canceled
+   * @param projection                  function to map the
+   *                                    {@link org.apache.kudu.client.RowResult}
+   *                                    to calcite object
+   * @param filterFunction              predicate to apply to
+   *                                    {@link org.apache.kudu.client.RowResult}
+   * @param isSingleObject              boolean indicating if the projection
+   *                                    returns Object[] or Object
+   * @param sortedPrefixKeySelector     the subset of columns being sorted by that
+   *                                    are a prefix of the primary key of the
+   *                                    table, or an empty list if the group by
+   *                                    and order by columns are the same
+   * @param sortPkColumnNames           the names of the primary key columns that
+   *                                    are present in the ORDER BY clause
    * @return Enumeration on the objects, Fields conform to
    *         {@link CalciteKuduTable#getRowType}.
    */
   public KuduEnumerable executeQuery(final List<List<CalciteKuduPredicate>> predicates,
-      final List<Integer> columnIndices, final long limit, final long offset, final boolean sorted,
-      final boolean groupByLimited, final KuduScanStats scanStats, final AtomicBoolean cancelFlag,
+      final List<Integer> columnIndices, final long limit, final long offset, final long snapshotDiffFromCurrentTime,
+      final boolean sorted, final boolean groupByLimited, final KuduScanStats scanStats, final AtomicBoolean cancelFlag,
       final Function1<Object, Object> projection, final Predicate1<Object> filterFunction, final boolean isSingleObject,
       final Function1<Object, Object> sortedPrefixKeySelector, final List<String> sortPkColumnNames) {
-    return new KuduEnumerable(predicates, columnIndices, this.client, this, limit, offset, sorted, groupByLimited,
-        scanStats, cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumnNames);
+    return new KuduEnumerable(predicates, columnIndices, this.client, this, limit, offset, snapshotDiffFromCurrentTime,
+        sorted, groupByLimited, scanStats, cancelFlag, projection, filterFunction, isSingleObject,
+        sortedPrefixKeySelector, sortPkColumnNames);
   }
 
   @Override
@@ -279,7 +283,7 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
     public Enumerator<T> enumerator() {
       // noinspection unchecked
       final Enumerable<T> enumerable = (Enumerable<T>) getTable().executeQuery(Collections.emptyList(),
-          Collections.emptyList(), -1, -1, false, false, new KuduScanStats(), new AtomicBoolean(false), null, null,
+          Collections.emptyList(), -1, -1, 0l, false, false, new KuduScanStats(), new AtomicBoolean(false), null, null,
           false, null, null);
       return enumerable.enumerator();
     }
@@ -298,39 +302,44 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
      * This is the method that is called by Code generation to run the query. Code
      * generation happens in {@link KuduToEnumerableConverter}
      *
-     * @param predicates              filters for each of the independent scans
-     * @param fieldsIndices           the column indexes to fetch from the table
-     * @param limit                   maximum number of rows to fetch from the table
-     * @param offset                  the number of rows to skip from the table
-     * @param sorted                  whether the query needs to be sorted by key
-     * @param groupByLimited          whether the query contains a sorted
-     *                                aggregation
-     * @param scanStats               stat collector for the query
-     * @param cancelFlag              atomic boolean that is true when the query
-     *                                should be canceled
-     * @param projection              function to turn
-     *                                {@link org.apache.kudu.client.RowResult} into
-     *                                Calcite type
-     * @param filterFunction          filter applied to all
-     *                                {@link org.apache.kudu.client.RowResult}
-     * @param isSingleObject          indicates whether Calcite type is Object or
-     *                                Object[]
-     * @param sortedPrefixKeySelector the subset of columns being sorted by that are
-     *                                a prefix of the primary key of the table, or
-     *                                an empty list if the group by and order by
-     *                                columns are the same
-     * @param sortPkColumnNames       the names of the primary key columns that are
-     *                                present in the ORDER BY clause
+     * @param predicates                  filters for each of the independent scans
+     * @param fieldsIndices               the column indexes to fetch from the table
+     * @param limit                       maximum number of rows to fetch from the
+     *                                    table
+     * @param offset                      the number of rows to skip from the table
+     * @param snapshotDiffFromCurrentTime time in milliseconds before current time
+     *                                    to read table state at
+     * @param sorted                      whether the query needs to be sorted by
+     *                                    key
+     * @param groupByLimited              whether the query contains a sorted
+     *                                    aggregation
+     * @param scanStats                   stat collector for the query
+     * @param cancelFlag                  atomic boolean that is true when the query
+     *                                    should be canceled
+     * @param projection                  function to turn
+     *                                    {@link org.apache.kudu.client.RowResult}
+     *                                    into Calcite type
+     * @param filterFunction              filter applied to all
+     *                                    {@link org.apache.kudu.client.RowResult}
+     * @param isSingleObject              indicates whether Calcite type is Object
+     *                                    or Object[]
+     * @param sortedPrefixKeySelector     the subset of columns being sorted by that
+     *                                    are a prefix of the primary key of the
+     *                                    table, or an empty list if the group by
+     *                                    and order by columns are the same
+     * @param sortPkColumnNames           the names of the primary key columns that
+     *                                    are present in the ORDER BY clause
      * @return Enumerable for the query
      */
     public Enumerable<Object> query(final List<List<CalciteKuduPredicate>> predicates,
-        final List<Integer> fieldsIndices, final long limit, final long offset, final boolean sorted,
-        final boolean groupByLimited, final KuduScanStats scanStats, final AtomicBoolean cancelFlag,
-        final Function1<Object, Object> projection, final Predicate1<Object> filterFunction,
-        final boolean isSingleObject, final Function1<Object, Object> sortedPrefixKeySelector,
-        final List<String> sortPkColumnNames) {
-      return getTable().executeQuery(predicates, fieldsIndices, limit, offset, sorted, groupByLimited, scanStats,
-          cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumnNames);
+        final List<Integer> fieldsIndices, final long limit, final long offset, final long snapshotDiffFromCurrentTime,
+        final boolean sorted, final boolean groupByLimited, final KuduScanStats scanStats,
+        final AtomicBoolean cancelFlag, final Function1<Object, Object> projection,
+        final Predicate1<Object> filterFunction, final boolean isSingleObject,
+        final Function1<Object, Object> sortedPrefixKeySelector, final List<String> sortPkColumnNames) {
+      return getTable().executeQuery(predicates, fieldsIndices, limit, offset, snapshotDiffFromCurrentTime, sorted,
+          groupByLimited, scanStats, cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector,
+          sortPkColumnNames);
     }
 
     /**

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduEnumerable.java
@@ -599,8 +599,6 @@ public final class KuduEnumerable extends AbstractEnumerable<Object> implements 
       // Allows for consistent row order in reads as it puts in ORDERED by Pk when
       // faultTolerant is set to true
       // setFaultTolerant to true sets the ReadMode to READ_AT_SNAPSHOT
-      // setting snapshot time to 1ms before currentTimestamp to avoid latency issues
-      // for tests.
       // setting snapshot time to time set through constructor or else default to
       // 0ms/current time.
       tokenBuilder.snapshotTimestampMicros((System.currentTimeMillis() * 1000) - (snapshotDiffFromCurrentTime * 1000));

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduMethod.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduMethod.java
@@ -30,8 +30,8 @@ import org.apache.calcite.rel.core.Join;
  */
 public enum KuduMethod {
   KUDU_QUERY_METHOD(CalciteKuduTable.KuduQueryable.class, "query", List.class, List.class, int.class, int.class,
-      boolean.class, boolean.class, KuduScanStats.class, AtomicBoolean.class, Function1.class, Predicate1.class,
-      boolean.class, Function1.class, List.class),
+      long.class, boolean.class, boolean.class, KuduScanStats.class, AtomicBoolean.class, Function1.class,
+      Predicate1.class, boolean.class, Function1.class, List.class),
   KUDU_MUTATE_TUPLES_METHOD(CalciteKuduTable.KuduQueryable.class, "mutateTuples", List.class, List.class),
   KUDU_MUTATE_ROW_METHOD(CalciteKuduTable.KuduQueryable.class, "mutateRow", List.class, List.class),
   NESTED_JOIN_PREDICATES(KuduEnumerable.class, "nestedJoinPredicates", Join.class);

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
@@ -75,6 +75,7 @@ public interface KuduRelNode extends RelNode {
     public final List<List<CalciteKuduPredicate>> predicates = new ArrayList<>();
     public long limit = -1;
     public long offset = -1;
+    public long snapshotDiffFromCurrentTime = 0l;
     public boolean sorted = false;
     public boolean groupByLimited = false;
     // if groupByLimited is true and sortPkPrefixColumns is empty

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduToEnumerableRel.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduToEnumerableRel.java
@@ -109,6 +109,9 @@ public class KuduToEnumerableRel extends ConverterImpl implements EnumerableRel 
 
     final Expression offset = list.append("offset", Expressions.constant(kuduImplementor.offset));
 
+    final Expression snapshotDiffFromCurrentTime = list.append("snapshotDiffFromCurrentTime",
+        Expressions.constant(kuduImplementor.snapshotDiffFromCurrentTime));
+
     final Expression sorted = list.append("sorted", Expressions.constant(kuduImplementor.sorted));
 
     final Expression table = list.append("table",
@@ -229,9 +232,9 @@ public class KuduToEnumerableRel extends ConverterImpl implements EnumerableRel 
         implementor.stash(kuduImplementor.sortPkColumns, List.class));
 
     final Expression enumerable = list.append("enumerable",
-        Expressions.call(table, KuduMethod.KUDU_QUERY_METHOD.method, predicates, fields, limit, offset, sorted,
-            Expressions.constant(kuduImplementor.groupByLimited), scanStats, cancelBoolean, mapFunction, filterFunction,
-            isSingleObject, sortedPrefixKeySelector, sortPkColumns));
+        Expressions.call(table, KuduMethod.KUDU_QUERY_METHOD.method, predicates, fields, limit, offset,
+            snapshotDiffFromCurrentTime, sorted, Expressions.constant(kuduImplementor.groupByLimited), scanStats,
+            cancelBoolean, mapFunction, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumns));
 
     Hook.QUERY_PLAN.run(predicates);
     list.add(Expressions.return_(null, enumerable));

--- a/adapter/src/test/java/com/twilio/kudu/sql/KuduQueryIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/KuduQueryIT.java
@@ -117,9 +117,9 @@ public class KuduQueryIT {
 
     final CalciteKuduPredicate filterToSid = new ComparisonPredicate(2, KuduPredicate.ComparisonOp.EQUAL, "SM1234857");
     final Enumerable<Object> results = relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), -1, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true, null,
-        null);
+        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), -1, -1, 0l,
+        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true,
+        null, null);
     Iterator<Object> resultIter = results.iterator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.hasNext());
@@ -135,9 +135,9 @@ public class KuduQueryIT {
     final CalciteKuduPredicate filterToAccountSid = new ComparisonPredicate(0, KuduPredicate.ComparisonOp.EQUAL,
         KuduQueryIT.ACCOUNT_SID);
     final Enumerable<Object> results = relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToAccountSid)), Arrays.asList(2, 0), -1, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null,
-        null);
+        Collections.singletonList(Collections.singletonList(filterToAccountSid)), Arrays.asList(2, 0), -1, -1, 0l,
+        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false,
+        null, null);
     Iterator<Object> resultIter = results.iterator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.hasNext());
@@ -173,7 +173,7 @@ public class KuduQueryIT {
     predicateQuery.add(Arrays.asList(firstSid));
     predicateQuery.add(Arrays.asList(secondSid));
 
-    final Enumerable<Object> results = relTable.executeQuery(predicateQuery, Collections.singletonList(2), -1, -1,
+    final Enumerable<Object> results = relTable.executeQuery(predicateQuery, Collections.singletonList(2), -1, -1, 0l,
         false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true,
         null, null);
     Enumerator<Object> resultIter = results.enumerator();
@@ -200,15 +200,15 @@ public class KuduQueryIT {
     // Logic now pushes the limit into all the scanners even if there is no
     // RelCollation
     KuduEnumerable kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null,
-        null);
+        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, -1, 0l,
+        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false,
+        null, null);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals("Each scanner should have pushed down the limit of 3 into the scan", 3L, scanner.getLimit());
     }
 
     kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, 4, true,
+        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, 4, 0l, true,
         false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null,
         null);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
@@ -218,9 +218,9 @@ public class KuduQueryIT {
 
     // since we sorting assert that the limit is pushed down into the kudu scanner
     kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, -1, true,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null,
-        null);
+        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), 3, -1, 0l,
+        true, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false,
+        null, null);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals(3, scanner.getLimit());
     }
@@ -228,9 +228,9 @@ public class KuduQueryIT {
     // even though we ask not to sort, since we set an offset the enumerable forces
     // a sort
     kuduEnumerable = (KuduEnumerable) relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), -1, 1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false, null,
-        null);
+        Collections.singletonList(Collections.singletonList(filterToSid)), Collections.singletonList(2), -1, 1, 0l,
+        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false,
+        null, null);
     Assert.assertTrue(kuduEnumerable.sort);
     for (AsyncKuduScanner scanner : kuduEnumerable.getScanners()) {
       Assert.assertEquals(Long.MAX_VALUE, scanner.getLimit());
@@ -257,7 +257,7 @@ public class KuduQueryIT {
     predicateQuery.add(Arrays.asList(firstSid));
     predicateQuery.add(Arrays.asList(secondSid));
 
-    final Enumerable<Object> results = relTable.executeQuery(predicateQuery, Collections.singletonList(2), -1, -1,
+    final Enumerable<Object> results = relTable.executeQuery(predicateQuery, Collections.singletonList(2), -1, -1, 0l,
         false, false, new KuduScanStats(), new AtomicBoolean(true), MAP_RESPONSE_TWO_STRINGS, Predicate1.TRUE, false,
         null, null);
     Enumerator<Object> resultIter = results.enumerator();
@@ -279,9 +279,9 @@ public class KuduQueryIT {
     final CalciteKuduPredicate filterToAccountSid = new ComparisonPredicate(0, KuduPredicate.ComparisonOp.EQUAL,
         KuduQueryIT.ACCOUNT_SID);
     final Enumerable<Object> results = relTable.executeQuery(
-        Collections.singletonList(Collections.singletonList(filterToAccountSid)), Arrays.asList(2, 0), -1, -1, false,
-        false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true, null,
-        null);
+        Collections.singletonList(Collections.singletonList(filterToAccountSid)), Arrays.asList(2, 0), -1, -1, 0l,
+        false, false, new KuduScanStats(), new AtomicBoolean(false), MAP_RESPONSE_ONE_STRING, Predicate1.TRUE, true,
+        null, null);
     Iterator<Object> resultIter = results.iterator();
 
     Assert.assertTrue("Should have something to iterate over", resultIter.hasNext());


### PR DESCRIPTION
Add snapshot diff variable to configure how long back to look into the past per query. 
Essential for fault tolerant scanners to look inside replicas when leader tablets are not reachable and a new leader has not yet been elected. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [Y] I acknowledge that all my contributions will be made under the project's license.
