### PR TITLE
Use DISABLE_IN_LIST_OPTIMIZATION to use OR clause for IN queries

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
@@ -195,7 +195,7 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
   public RelNode toRel(final RelOptTable.ToRelContext context, final RelOptTable relOptTable) {
 
     final RelOptCluster cluster = context.getCluster();
-    return new KuduQuery(cluster, cluster.traitSetOf(KuduRelNode.CONVENTION), relOptTable, this,
+    return new KuduQuery(cluster, cluster.traitSetOf(KuduRelNode.CONVENTION), relOptTable, context.getTableHints(), this,
         this.getRowType(context.getCluster().getTypeFactory()));
   }
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
@@ -195,8 +195,8 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
   public RelNode toRel(final RelOptTable.ToRelContext context, final RelOptTable relOptTable) {
 
     final RelOptCluster cluster = context.getCluster();
-    return new KuduQuery(cluster, cluster.traitSetOf(KuduRelNode.CONVENTION), relOptTable, context.getTableHints(), this,
-        this.getRowType(context.getCluster().getTypeFactory()));
+    return new KuduQuery(cluster, cluster.traitSetOf(KuduRelNode.CONVENTION), relOptTable, context.getTableHints(),
+        this, this.getRowType(context.getCluster().getTypeFactory()));
   }
 
   /**

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -46,7 +46,7 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
   final public CalciteKuduTable calciteKuduTable;
 
   public static HintStrategyTable KUDU_HINT_STRATEGY_TABLE = HintStrategyTable.builder()
-      .hintStrategy(KuduNestedJoinRule.HINT_NAME, HintPredicates.JOIN).hintStrategy(KuduFilterRule.HINT_NAME, HintPredicates.SET_VAR).build();
+      .hintStrategy(KuduNestedJoinRule.HINT_NAME, HintPredicates.JOIN).hintStrategy(KuduFilterRule.HINT_NAME, HintPredicates.SET_VAR).hintStrategy(KuduFilterRule.HINT_NAME, HintPredicates.TABLE_SCAN).build();
 
   /**
    * List of column indices that are stored in reverse order.

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -15,6 +15,7 @@
 package com.twilio.kudu.sql;
 
 import com.google.common.collect.Sets;
+import com.twilio.kudu.sql.rules.KuduFilterRule;
 import com.twilio.kudu.sql.rules.KuduNestedJoinRule;
 import com.twilio.kudu.sql.rules.KuduRules;
 import org.apache.calcite.adapter.enumerable.EnumerableRules;
@@ -45,7 +46,7 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
   final public CalciteKuduTable calciteKuduTable;
 
   public static HintStrategyTable KUDU_HINT_STRATEGY_TABLE = HintStrategyTable.builder()
-      .hintStrategy(KuduNestedJoinRule.HINT_NAME, HintPredicates.JOIN).build();
+      .hintStrategy(KuduNestedJoinRule.HINT_NAME, HintPredicates.JOIN).hintStrategy(KuduFilterRule.HINT_NAME, HintPredicates.SET_VAR).build();
 
   /**
    * List of column indices that are stored in reverse order.

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -53,6 +53,7 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
    * @param cluster          Cluster
    * @param traitSet         Traits
    * @param table            Table
+   * @param hints            List<RelHint>
    * @param calciteKuduTable Kudu table
    * @param projectRowType   Fields and types to project; null to project raw row
    */

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -34,7 +34,6 @@ import org.apache.calcite.rel.type.RelDataType;
 
 import java.util.List;
 
-
 /**
  * Relational expression representing a scan of a KuduTable
  */
@@ -42,7 +41,8 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
   final public CalciteKuduTable calciteKuduTable;
 
   public static HintStrategyTable KUDU_HINT_STRATEGY_TABLE = HintStrategyTable.builder()
-      .hintStrategy(KuduNestedJoinRule.HINT_NAME, HintPredicates.JOIN).hintStrategy(KuduFilterRule.HINT_NAME, HintPredicates.TABLE_SCAN).build();
+      .hintStrategy(KuduNestedJoinRule.HINT_NAME, HintPredicates.JOIN)
+      .hintStrategy(KuduFilterRule.HINT_NAME, HintPredicates.TABLE_SCAN).build();
 
   /**
    * List of column indices that are stored in reverse order.
@@ -56,8 +56,8 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
    * @param calciteKuduTable Kudu table
    * @param projectRowType   Fields and types to project; null to project raw row
    */
-  public KuduQuery(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table, List<RelHint> hints, CalciteKuduTable calciteKuduTable,
-                   RelDataType projectRowType) {
+  public KuduQuery(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table, List<RelHint> hints,
+      CalciteKuduTable calciteKuduTable, RelDataType projectRowType) {
     super(cluster, traitSet, hints, table);
     this.calciteKuduTable = calciteKuduTable;
     this.projectRowType = projectRowType;

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.hint.RelHint;
 
 import java.util.List;
 
@@ -53,7 +54,7 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
    * @param cluster          Cluster
    * @param traitSet         Traits
    * @param table            Table
-   * @param hints            List<RelHint>
+   * @param hints            {@code RelHint} list
    * @param calciteKuduTable Kudu table
    * @param projectRowType   Fields and types to project; null to project raw row
    */

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -14,7 +14,6 @@
  */
 package com.twilio.kudu.sql;
 
-import com.google.common.collect.Sets;
 import com.twilio.kudu.sql.rules.KuduFilterRule;
 import com.twilio.kudu.sql.rules.KuduNestedJoinRule;
 import com.twilio.kudu.sql.rules.KuduRules;
@@ -33,6 +32,7 @@ import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.hint.RelHint;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -110,6 +110,12 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
     if (CalciteSystemProperty.ENABLE_ENUMERABLE.value()) {
       KuduRules.ENUMERABLE_RULES.stream().forEach(r -> planner.addRule(r));
     }
+  }
+
+  @Override
+  public RelNode withHints(List<RelHint> hintList) {
+    return new KuduQuery(this.getCluster(), this.traitSet, this.table, hintList, this.calciteKuduTable,
+        this.projectRowType);
   }
 
   @Override

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -167,6 +167,7 @@ public class KuduAggregationLimitRule extends RelOptRule {
 
   public Pair<List<RelFieldCollation>, List<String>> getSortPkPrefix(final RelCollation originalCollation,
       final RelCollation newCollation, final KuduQuery query, final Optional<Filter> filter) {
+    boolean isDisableInListOptimizationHintPresent = false;
     final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
     final List<RelFieldCollation> sortPrefixColumns = Lists.newArrayList();
     final List<String> sortPkColumns = Lists.newArrayList();
@@ -192,7 +193,8 @@ public class KuduAggregationLimitRule extends RelOptRule {
           final RexBuilder rexBuilder = filter.get().getCluster().getRexBuilder();
           final RexNode originalCondition = RexUtil.expandSearch(rexBuilder, null, filter.get().getCondition());
           while (pkColumnIndex < sortField.getFieldIndex()) {
-            final KuduSortRule.KuduFilterVisitor visitor = new KuduSortRule.KuduFilterVisitor(pkColumnIndex);
+            final KuduSortRule.KuduFilterVisitor visitor = new KuduSortRule.KuduFilterVisitor(pkColumnIndex,
+                isDisableInListOptimizationHintPresent);
             final Boolean foundFieldInCondition = originalCondition.accept(visitor);
             if (foundFieldInCondition.equals(Boolean.FALSE)) {
               return pair;

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class KuduFilterRule extends RelOptRule {
 
-  public static final String HINT_NAME = "USE_OR_CLAUSE";
+  public static final String HINT_NAME = "DISABLE_IN_LIST_OPTIMIZATION";
 
   public KuduFilterRule(RelBuilderFactory relBuilderFactory) {
     super(operand(LogicalFilter.class, operand(KuduQuery.class, none())), relBuilderFactory, "KuduPushDownFilters");

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
@@ -30,6 +30,8 @@ import org.apache.calcite.tools.RelBuilderFactory;
 import java.util.List;
 
 public class KuduFilterRule extends RelOptRule {
+
+  public static final String HINT_NAME = "USE_OR_CLAUSE";
   public KuduFilterRule(RelBuilderFactory relBuilderFactory) {
     super(operand(LogicalFilter.class, operand(KuduQuery.class, none())), relBuilderFactory, "KuduPushDownFilters");
   }
@@ -48,8 +50,15 @@ public class KuduFilterRule extends RelOptRule {
       RowValueExpressionConverter visitor = new RowValueExpressionConverter(rexBuilder, kuduQuery.calciteKuduTable);
       final RexNode condition = filter.getCondition().accept(visitor);
       int primaryKeyColumnCount = kuduQuery.calciteKuduTable.getKuduTable().getSchema().getPrimaryKeyColumnCount();
-      final KuduPredicatePushDownVisitor predicateParser = new KuduPredicatePushDownVisitor(rexBuilder,
-          primaryKeyColumnCount);
+      final KuduPredicatePushDownVisitor predicateParser;
+      if(kuduQuery.getHints().stream().map(h -> h.hintName).anyMatch(s -> s.equalsIgnoreCase(HINT_NAME))){
+        predicateParser = new KuduPredicatePushDownVisitor(rexBuilder,
+                primaryKeyColumnCount, true);
+      }else{
+        predicateParser = new KuduPredicatePushDownVisitor(rexBuilder,
+                primaryKeyColumnCount, false);
+      }
+
 
       List<List<CalciteKuduPredicate>> predicates = condition.accept(predicateParser, null);
       if (predicates.isEmpty()) {

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduFilterRule.java
@@ -32,6 +32,7 @@ import java.util.List;
 public class KuduFilterRule extends RelOptRule {
 
   public static final String HINT_NAME = "USE_OR_CLAUSE";
+
   public KuduFilterRule(RelBuilderFactory relBuilderFactory) {
     super(operand(LogicalFilter.class, operand(KuduQuery.class, none())), relBuilderFactory, "KuduPushDownFilters");
   }
@@ -51,14 +52,11 @@ public class KuduFilterRule extends RelOptRule {
       final RexNode condition = filter.getCondition().accept(visitor);
       int primaryKeyColumnCount = kuduQuery.calciteKuduTable.getKuduTable().getSchema().getPrimaryKeyColumnCount();
       final KuduPredicatePushDownVisitor predicateParser;
-      if(kuduQuery.getHints().stream().map(h -> h.hintName).anyMatch(s -> s.equalsIgnoreCase(HINT_NAME))){
-        predicateParser = new KuduPredicatePushDownVisitor(rexBuilder,
-                primaryKeyColumnCount, true);
-      }else{
-        predicateParser = new KuduPredicatePushDownVisitor(rexBuilder,
-                primaryKeyColumnCount, false);
+      if (kuduQuery.getHints().stream().map(h -> h.hintName).anyMatch(s -> s.equalsIgnoreCase(HINT_NAME))) {
+        predicateParser = new KuduPredicatePushDownVisitor(rexBuilder, primaryKeyColumnCount, true);
+      } else {
+        predicateParser = new KuduPredicatePushDownVisitor(rexBuilder, primaryKeyColumnCount, false);
       }
-
 
       List<List<CalciteKuduPredicate>> predicates = condition.accept(predicateParser, null);
       if (predicates.isEmpty()) {

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
@@ -176,7 +176,7 @@ public class KuduPredicatePushDownVisitor implements RexBiVisitor<List<List<Calc
     int columnIndex = getColumnIndex(call.operands.get(0));
     // If disableInListOptimization is true use an OR clause which ends up
     // generating a separate scan token for
-    // each clause. this is required for Org queries in case we are sorting by a
+    // each clause. this is required in case we are sorting by a
     // part of the primary key
     if (sarg.isPoints() && !disableInListOptimization) {
       final List<RexNode> inNodes = sarg.rangeSet.asRanges().stream()

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
@@ -193,7 +193,7 @@ public class KuduPredicatePushDownVisitor implements RexBiVisitor<List<List<Calc
     // TODO see if there is a way to only force using an OR clause when sorting by
     // part of the
     // primary key
-    if (columnIndex > primaryKeyColumnCount && sarg.isPoints() && useOrClause) {
+    if ((columnIndex > primaryKeyColumnCount && sarg.isPoints()) || !useOrClause) {
       final List<RexNode> inNodes = sarg.rangeSet.asRanges().stream()
           .map(range -> rexBuilder.makeLiteral(range.lowerEndpoint(), literal.getType(), true, true))
           .collect(Collectors.toList());

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
@@ -90,10 +90,12 @@ public class KuduPredicatePushDownVisitor implements RexBiVisitor<List<List<Calc
 
   private final RexBuilder rexBuilder;
   private final int primaryKeyColumnCount;
+  private final boolean useOrClause;
 
-  public KuduPredicatePushDownVisitor(RexBuilder rexBuilder, int primaryKeyColumnCount) {
+  public KuduPredicatePushDownVisitor(RexBuilder rexBuilder, int primaryKeyColumnCount, boolean useOrClause) {
     this.rexBuilder = rexBuilder;
     this.primaryKeyColumnCount = primaryKeyColumnCount;
+    this.useOrClause = useOrClause;
   }
 
   /**
@@ -191,7 +193,7 @@ public class KuduPredicatePushDownVisitor implements RexBiVisitor<List<List<Calc
     // TODO see if there is a way to only force using an OR clause when sorting by
     // part of the
     // primary key
-    if (columnIndex > primaryKeyColumnCount && sarg.isPoints()) {
+    if (columnIndex > primaryKeyColumnCount && sarg.isPoints() && useOrClause) {
       final List<RexNode> inNodes = sarg.rangeSet.asRanges().stream()
           .map(range -> rexBuilder.makeLiteral(range.lowerEndpoint(), literal.getType(), true, true))
           .collect(Collectors.toList());

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
@@ -174,13 +174,10 @@ public class KuduPredicatePushDownVisitor implements RexBiVisitor<List<List<Calc
     final RexLiteral literal = (RexLiteral) call.operands.get(1);
     final Sarg<C> sarg = literal.getValueAs(Sarg.class);
     int columnIndex = getColumnIndex(call.operands.get(0));
-    // if we have an IN list on a primary key count do not use an IN list predicate,
-    // instead use an OR clause which ends up generating a separate scan token for
-    // each clause
-    // this is required in case we are sorting by a part of the primary key
-    // TODO see if there is a way to only force using an OR clause when sorting by
-    // part of the
-    // primary key
+    // If disableInListOptimization is true use an OR clause which ends up
+    // generating a separate scan token for
+    // each clause. this is required for Org queries in case we are sorting by a
+    // part of the primary key
     if (sarg.isPoints() && !disableInListOptimization) {
       final List<RexNode> inNodes = sarg.rangeSet.asRanges().stream()
           .map(range -> rexBuilder.makeLiteral(range.lowerEndpoint(), literal.getType(), true, true))

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduPredicatePushDownVisitor.java
@@ -193,7 +193,7 @@ public class KuduPredicatePushDownVisitor implements RexBiVisitor<List<List<Calc
     // TODO see if there is a way to only force using an OR clause when sorting by
     // part of the
     // primary key
-    if ((columnIndex > primaryKeyColumnCount && sarg.isPoints()) || !useOrClause) {
+    if (sarg.isPoints() && !useOrClause) {
       final List<RexNode> inNodes = sarg.rangeSet.asRanges().stream()
           .map(range -> rexBuilder.makeLiteral(range.lowerEndpoint(), literal.getType(), true, true))
           .collect(Collectors.toList());

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -68,6 +68,10 @@ public abstract class KuduSortRule extends RelOptRule {
 
   public boolean canApply(final RelTraitSet sortTraits, final KuduQuery query, final KuduTable openedTable,
       final Optional<Filter> filter) {
+    boolean isDisableInListOptimizationHintPresent = false;
+    if (query.getHints().stream().map(h -> h.hintName).anyMatch(s -> s.equalsIgnoreCase(KuduFilterRule.HINT_NAME))) {
+      isDisableInListOptimizationHintPresent = true;
+    }
     // If there is no sort -- i.e. there is only a limit
     // don't pay the cost of returning rows in sorted order.
     final RelCollation collation = sortTraits.getTrait(RelCollationTraitDef.INSTANCE);
@@ -104,7 +108,8 @@ public abstract class KuduSortRule extends RelOptRule {
           final RexBuilder rexBuilder = filter.get().getCluster().getRexBuilder();
           final RexNode originalCondition = RexUtil.expandSearch(rexBuilder, null, filter.get().getCondition());
           while (pkColumnIndex < sortField.getFieldIndex()) {
-            final KuduFilterVisitor visitor = new KuduFilterVisitor(pkColumnIndex);
+            final KuduFilterVisitor visitor = new KuduFilterVisitor(pkColumnIndex,
+                isDisableInListOptimizationHintPresent);
             final Boolean foundFieldInCondition = originalCondition.accept(visitor);
             if (foundFieldInCondition.equals(Boolean.FALSE)) {
               return false;
@@ -184,10 +189,12 @@ public abstract class KuduSortRule extends RelOptRule {
    */
   public static class KuduFilterVisitor extends RexVisitorImpl<Boolean> {
     public final int mustHave;
+    public final boolean isDisableInListOptimizationPresent;
 
-    public KuduFilterVisitor(final int mustHave) {
+    public KuduFilterVisitor(final int mustHave, final boolean isDisableInListOptimizationPresent) {
       super(true);
       this.mustHave = mustHave;
+      this.isDisableInListOptimizationPresent = isDisableInListOptimizationPresent;
     }
 
     public Boolean visitInputRef(final RexInputRef inputRef) {
@@ -224,6 +231,9 @@ public abstract class KuduSortRule extends RelOptRule {
           if (!operand.accept(this).equals(Boolean.TRUE)) {
             return Boolean.FALSE;
           }
+        }
+        if (!isDisableInListOptimizationPresent) {
+          return Boolean.FALSE;
         }
         return Boolean.TRUE;
       }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -224,6 +224,9 @@ public abstract class KuduSortRule extends RelOptRule {
         }
         return Boolean.FALSE;
       case OR:
+        if (!isDisableInListOptimizationPresent) {
+          return Boolean.FALSE;
+        }
         // if all of the operands of the OR clause contain the mustHave column then we
         // can
         // return true
@@ -231,9 +234,6 @@ public abstract class KuduSortRule extends RelOptRule {
           if (!operand.accept(this).equals(Boolean.TRUE)) {
             return Boolean.FALSE;
           }
-        }
-        if (!isDisableInListOptimizationPresent) {
-          return Boolean.FALSE;
         }
         return Boolean.TRUE;
       }

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -733,7 +733,7 @@ public class PaginationIT {
   }
 
   @Test
-  public void testPaginationMultipleAccountsOrderedByAccountSidUsingINWithoutHint() throws Exception {
+  public void testPaginationMultipleAccountsOrderedByAccountSidWithoutHint() throws Exception {
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       TimestampString lowerBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T1);
       TimestampString upperBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T4);
@@ -757,7 +757,7 @@ public class PaginationIT {
   }
 
   @Test
-  public void testPaginationMultipleAccountsOrderedByAccountSidUsingINWithoutHintOrderByDate() throws Exception {
+  public void testPaginationMultipleAccountsOrderedByDateWithoutHint() throws Exception {
     try (Connection conn = DriverManager.getConnection(JDBC_URL)) {
       TimestampString lowerBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T1);
       TimestampString upperBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T4);

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -768,10 +768,13 @@ public class PaginationIT {
       TimestampString lowerBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T1);
       TimestampString upperBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T4);
       String dateInitiatedOrder = descending ? "DESC" : "ASC";
-      String firstBatchSqlFormat = "SELECT * FROM %s WHERE account_sid IN ('ACCOUNT1','ACCOUNT2') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' "
+      String hint = "/*+ USE_OR_CLAUSE */";
+      String firstBatchSqlFormat = "SELECT %s * FROM %s WHERE account_sid IN ('ACCOUNT1','ACCOUNT2') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' "
               + "ORDER BY account_sid, date_initiated %s, transaction_id " + "LIMIT 7";
-      String firstBatchSql = String.format(firstBatchSqlFormat, tableName, lowerBoundDateInitiated,
+
+      String firstBatchSql = String.format(firstBatchSqlFormat, hint, tableName, lowerBoundDateInitiated,
               upperBoundDateInitiated, dateInitiatedOrder);
+     // String sql = String.format(firstBatchSql, hint);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
 

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.twilio.kudu.sql.metadata.KuduTableMetadata;
 import com.twilio.kudu.sql.schema.BaseKuduSchemaFactory;
-import com.twilio.kudu.sql.schema.DefaultKuduSchemaFactory;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.util.ImmutableBeans;
@@ -46,28 +45,18 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public class PaginationIT {
@@ -87,7 +76,6 @@ public class PaginationIT {
   public static final long T3 = 3000;
   public static final long T4 = 4000;
   public static final String[] ACCOUNTS = new String[] { ACCOUNT1, ACCOUNT2 };
-  public static final String TEST_ORGANIZATION_SID = "ORcaba0759581b24aad1915c70c866f1bb";
   public static final long[] TIMESTAMP_PARTITIONS = new long[] { T1, T2, T3 };
   public static final int NUM_ROWS_PER_PARTITION = 10;
   public static KuduTable kuduTable;

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -84,7 +84,7 @@ public class PaginationIT {
   private final String tableName;
 
   private static String JDBC_URL;
-  private static String hint = "/*+ USE_OR_CLAUSE */";
+  private static String hint = "/*+ DISABLE_IN_LIST_OPTIMIZATION */";
 
   @Parameterized.Parameters(name = "PaginationIT_descending={0}")
   public static synchronized Collection<Boolean> data() {

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -136,9 +136,9 @@ public class PaginationIT {
   public static void initializeHints() {
     try {
       SqlToRelConverter.Config CONFIG_MODIFIED = ImmutableBeans.create(SqlToRelConverter.Config.class)
-              .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
-              .withRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
-              .withHintStrategyTable(KuduQuery.KUDU_HINT_STRATEGY_TABLE);
+          .withRelBuilderFactory(RelFactories.LOGICAL_BUILDER)
+          .withRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
+          .withHintStrategyTable(KuduQuery.KUDU_HINT_STRATEGY_TABLE);
       // change SqlToRelConverter.CONFIG to use one that has the above
       // HintStrategyTable
       setFinalStatic(SqlToRelConverter.class.getDeclaredField("CONFIG"), CONFIG_MODIFIED);
@@ -156,7 +156,6 @@ public class PaginationIT {
 
     field.set(null, newValue);
   }
-
 
   private static Timestamp normalizeTimestamp(boolean descending, long ts) {
     return new Timestamp(descending ? CalciteKuduTable.EPOCH_FOR_REVERSE_SORT_IN_MILLISECONDS - ts : ts);
@@ -345,7 +344,6 @@ public class PaginationIT {
       assertFalse(rs.next());
     }
   }
-
 
   @Test
   public void testSortWithFilterAndLimitAndOffset() throws Exception {
@@ -726,21 +724,21 @@ public class PaginationIT {
       String dateInitiatedOrder = descending ? "DESC" : "ASC";
       String hint = "/*+ USE_OR_CLAUSE */";
       String firstBatchSqlFormat = "SELECT * FROM %s %s WHERE account_sid IN ('ACCOUNT1','ACCOUNT2') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' "
-              + "ORDER BY account_sid, date_initiated %s, transaction_id " + "LIMIT 7";
+          + "ORDER BY account_sid, date_initiated %s, transaction_id " + "LIMIT 7";
 
       String firstBatchSql = String.format(firstBatchSqlFormat, tableName, hint, lowerBoundDateInitiated,
-              upperBoundDateInitiated, dateInitiatedOrder);
+          upperBoundDateInitiated, dateInitiatedOrder);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
 
       String expectedPlanFormat = "KuduToEnumerableRel\n"
-              + "  KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], dir2=[ASC], "
-              + "fetch=[7], groupBySorted=[false])\n"
-              + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, "
-              + "date_initiated LESS %d], ScanToken 2=[account_sid EQUAL %s, date_initiated "
-              + "GREATER_EQUAL %d, date_initiated LESS %d])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
+          + "  KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], dir2=[ASC], "
+          + "fetch=[7], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, "
+          + "date_initiated LESS %d], ScanToken 2=[account_sid EQUAL %s, date_initiated "
+          + "GREATER_EQUAL %d, date_initiated LESS %d])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
       String expectedPlan = String.format(expectedPlanFormat, dateInitiatedOrder, ACCOUNT1, T1 * 1000, T4 * 1000,
-              ACCOUNT2, T1 * 1000, T4 * 1000, tableName);
+          ACCOUNT2, T1 * 1000, T4 * 1000, tableName);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
     }
   }
@@ -752,17 +750,17 @@ public class PaginationIT {
       TimestampString upperBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T4);
       String dateInitiatedOrder = descending ? "DESC" : "ASC";
       String firstBatchSqlFormat = "SELECT * FROM %s WHERE account_sid IN ('ACCOUNT1','ACCOUNT2') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' "
-              + "ORDER BY account_sid, date_initiated %s, transaction_id " + "LIMIT 7";
+          + "ORDER BY account_sid, date_initiated %s, transaction_id " + "LIMIT 7";
 
       String firstBatchSql = String.format(firstBatchSqlFormat, tableName, lowerBoundDateInitiated,
-              upperBoundDateInitiated, dateInitiatedOrder);
+          upperBoundDateInitiated, dateInitiatedOrder);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
 
-      String expectedPlanFormat = "KuduToEnumerableRel\n" +
-              "  KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], dir2=[ASC], fetch=[7], groupBySorted=[false])\n" +
-              "    KuduFilterRel(ScanToken 1=[account_sid IN [ACCOUNT1, ACCOUNT2], date_initiated EQUAL 1000000])\n" +
-              "      KuduQuery(table=[[kudu, %s]])\n";
+      String expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], dir2=[ASC], fetch=[7], groupBySorted=[false])\n"
+          + "    KuduFilterRel(ScanToken 1=[account_sid IN [ACCOUNT1, ACCOUNT2], date_initiated EQUAL 1000000])\n"
+          + "      KuduQuery(table=[[kudu, %s]])\n";
 
       String expectedPlan = String.format(expectedPlanFormat, dateInitiatedOrder, tableName);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);

--- a/adapter/src/test/java/com/twilio/kudu/sql/rules/NumberFilterTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/rules/NumberFilterTest.java
@@ -46,7 +46,7 @@ public final class NumberFilterTest {
     final RexCall call = (RexCall) builder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
         Arrays.asList(fieldRef, amountFilter));
 
-    final KuduPredicatePushDownVisitor visitor = new KuduPredicatePushDownVisitor(builder, 0);
+    final KuduPredicatePushDownVisitor visitor = new KuduPredicatePushDownVisitor(builder, 0, false);
 
     final ComparisonPredicate predicate = (ComparisonPredicate) visitor.visitLiteral(amountFilter, call).get(0).get(0);
     Assert.assertEquals("The amount should match what was passed in", new BigDecimal("0.5"), predicate.rightHandValue);


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Existing changes result in OR being applied to all IN clauses. Inorder to avoid that we 
1. Provide hint DISABLE_IN_LIST_OPTIMIZATION to use OR clause for IN queries needed for Org queries
2. Verified locally KJ test OutboundMessagesIT and OrganizationPaginationIT pass after these changes

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
