### PR TITLE
Fix bug in KuduImplementor sortPkColumns usage.

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
@@ -78,8 +78,8 @@ public interface KuduRelNode extends RelNode {
     public boolean groupByLimited = false;
     // if groupByLimited is true and sortPkPrefixColumns is empty
     // that means we are sorting by the same columns as we are grouping by
-    public List<RelFieldCollation> sortPkPrefixColumns = Collections.emptyList();
-    public List<String> sortPkColumns = Collections.emptyList();
+    public List<RelFieldCollation> sortPkPrefixColumns = new ArrayList<>();
+    public List<String> sortPkColumns = new ArrayList<>();
 
     // information required for executing an update
     public List<Integer> columnIndexes;

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduSortRel.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduSortRel.java
@@ -111,7 +111,7 @@ public class KuduSortRel extends Sort implements KuduRelNode {
     }
 
     implementor.groupByLimited = groupBySorted;
-    implementor.sortPkPrefixColumns = sortPkPrefixColumns;
-    implementor.sortPkColumns = sortPkColumns;
+    implementor.sortPkPrefixColumns.addAll(sortPkPrefixColumns);
+    implementor.sortPkColumns.addAll(sortPkColumns);
   }
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Create a copy of the objects used for setting `sortPkPrefixColumns` and `sortPkColumns` in KuduImplementor. We have seen errors that might point to this being a bug.
```
Caused by: java.lang.IllegalStateException: Unable to find primary key column event_date in the projection.
	at com.twilio.kudu.sql.CalciteKuduTable.getPrimaryKeyColumnsInProjection(CalciteKuduTable.java:413)
	at com.twilio.kudu.sql.ScannerCallback.<init>(ScannerCallback.java:75)
	at com.twilio.kudu.sql.KuduEnumerable.lambda$enumerator$0(KuduEnumerable.java:410)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
