### PR TITLE
 Fix bug in KuduImplementor sortPkColumns usage

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/CalciteKuduTable.java
@@ -234,8 +234,8 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
    *                                a prefix of the primary key of the table, or
    *                                an empty list if the group by and order by
    *                                columns are the same
-   * @param sortPkColumnNames       the names of the primary key columns that are
-   *                                present in the ORDER BY clause
+   * @param sortPkColumns           the indexes of the primary key columns that
+   *                                are present in the ORDER BY clause
    * @return Enumeration on the objects, Fields conform to
    *         {@link CalciteKuduTable#getRowType}.
    */
@@ -243,9 +243,9 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
       final List<Integer> columnIndices, final long limit, final long offset, final boolean sorted,
       final boolean groupByLimited, final KuduScanStats scanStats, final AtomicBoolean cancelFlag,
       final Function1<Object, Object> projection, final Predicate1<Object> filterFunction, final boolean isSingleObject,
-      final Function1<Object, Object> sortedPrefixKeySelector, final List<String> sortPkColumnNames) {
+      final Function1<Object, Object> sortedPrefixKeySelector, final List<Integer> sortPkColumns) {
     return new KuduEnumerable(predicates, columnIndices, this.client, this, limit, offset, sorted, groupByLimited,
-        scanStats, cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumnNames);
+        scanStats, cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumns);
   }
 
   @Override
@@ -325,7 +325,7 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
      *                                a prefix of the primary key of the table, or
      *                                an empty list if the group by and order by
      *                                columns are the same
-     * @param sortPkColumnNames       the names of the primary key columns that are
+     * @param sortPkColumns           the names of the primary key columns that are
      *                                present in the ORDER BY clause
      * @return Enumerable for the query
      */
@@ -334,9 +334,9 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
         final boolean groupByLimited, final KuduScanStats scanStats, final AtomicBoolean cancelFlag,
         final Function1<Object, Object> projection, final Predicate1<Object> filterFunction,
         final boolean isSingleObject, final Function1<Object, Object> sortedPrefixKeySelector,
-        final List<String> sortPkColumnNames) {
+        final List<Integer> sortPkColumns) {
       return getTable().executeQuery(predicates, fieldsIndices, limit, offset, sorted, groupByLimited, scanStats,
-          cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumnNames);
+          cancelFlag, projection, filterFunction, isSingleObject, sortedPrefixKeySelector, sortPkColumns);
     }
 
     /**
@@ -368,53 +368,6 @@ public class CalciteKuduTable extends AbstractQueryableTable implements Translat
       KuduMetaImpl kuduMetaImpl = ((KuduCalciteConnectionImpl) queryProvider).getMeta();
       return Linq4j.singletonEnumerable(kuduMetaImpl.getMutationState(table).mutateRow(columnIndexes, values));
     }
-  }
-
-  /**
-   * Return the Integer indices in the Row Projection that match the primary key
-   * columns and in the order they need to match. This lays out how to compare two
-   * {@code CalciteRow}s and determine which one is smaller.
-   * <p>
-   * As an example, imagine we have a table (A, B, C, D, E) with primary columns
-   * in order of (A, B) and we have a scanner SELECT D, C, E, B, A the
-   * projectedSchema will be D, C, E, B, A and the tableSchema will be A, B, C, D,
-   * E *this* function will return List(4, 3) -- the position's of A and B within
-   * the projection and in the order they need to be sorted by.
-   * <p>
-   * The returned index list is used by the sorted {@link KuduEnumerable} to merge
-   * the results from multiple scanners.
-   *
-   * @param projectedSchema   the Kudu Schema used in RPC requests
-   * @param sortPkColumnNames the names of the primary key columns that are
-   *                          present in the ORDER BY clause
-   *
-   * @return List of column indexes that part of the primary key in the Kudu
-   *         Sorted order
-   */
-  @VisibleForTesting
-  public static List<Integer> getPrimaryKeyColumnsInProjection(final List<String> sortPkColumnNames,
-      final Schema projectedSchema) {
-    final List<Integer> primaryKeyColumnsInProjection = new ArrayList<>();
-    final List<ColumnSchema> columnSchemas = projectedSchema.getColumns();
-
-    // KuduSortRule checks if the prefix of the primary key columns are being
-    // filtered and
-    // are set to a constant literal, or if the columns being sorted are a
-    // prefix of the primary key columns.
-    for (String sortPkColumnName : sortPkColumnNames) {
-      boolean found = false;
-      for (int columnIdx = 0; columnIdx < projectedSchema.getColumnCount(); columnIdx++) {
-        if (columnSchemas.get(columnIdx).getName().equals(sortPkColumnName)) {
-          primaryKeyColumnsInProjection.add(columnIdx);
-          found = true;
-        }
-      }
-      if (!found) {
-        throw new IllegalStateException(
-            "Unable to find primary key " + "column " + sortPkColumnName + " in the projection.");
-      }
-    }
-    return primaryKeyColumnsInProjection;
   }
 
   public CubeTableInfo.EventTimeAggregationType getEventTimeAggregationType() {

--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
@@ -79,7 +79,7 @@ public interface KuduRelNode extends RelNode {
     // if groupByLimited is true and sortPkPrefixColumns is empty
     // that means we are sorting by the same columns as we are grouping by
     public List<RelFieldCollation> sortPkPrefixColumns = new ArrayList<>();
-    public List<String> sortPkColumns = new ArrayList<>();
+    public List<Integer> sortPkColumns = new ArrayList<>();
 
     // information required for executing an update
     public List<Integer> columnIndexes;

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduSortRel.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduSortRel.java
@@ -51,15 +51,15 @@ public class KuduSortRel extends Sort implements KuduRelNode {
   // and
   // sortPrefixColumns is empty.
   public final List<RelFieldCollation> sortPkPrefixColumns;
-  public final List<String> sortPkColumns;
+  public final List<Integer> sortPkColumns;
 
   public KuduSortRel(RelOptCluster cluster, RelTraitSet traitSet, RelNode child, RelCollation collation, RexNode offset,
-      RexNode fetch, List<String> sortPkColumns) {
+      RexNode fetch, List<Integer> sortPkColumns) {
     this(cluster, traitSet, child, collation, offset, fetch, false, Lists.newArrayList(), sortPkColumns);
   }
 
   public KuduSortRel(RelOptCluster cluster, RelTraitSet traitSet, RelNode child, RelCollation collation, RexNode offset,
-      RexNode fetch, boolean groupBySorted, List<RelFieldCollation> sortPkPrefixColumns, List<String> sortPkColumns) {
+      RexNode fetch, boolean groupBySorted, List<RelFieldCollation> sortPkPrefixColumns, List<Integer> sortPkColumns) {
     super(cluster, traitSet, child, collation, offset, fetch);
     assert getConvention() == KuduRelNode.CONVENTION;
     assert getConvention() == child.getConvention();

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -127,7 +127,7 @@ public class KuduAggregationLimitRule extends RelOptRule {
     }
 
     // Check the new trait set to see if we can apply the sort against this.
-    final Pair<List<RelFieldCollation>, List<String>> pair = getSortPkPrefix(originalSort.getCollation(), newCollation,
+    final Pair<List<RelFieldCollation>, List<Integer>> pair = getSortPkPrefix(originalSort.getCollation(), newCollation,
         query, Optional.of(filter));
     if (pair.left.isEmpty()) {
       return;
@@ -165,13 +165,13 @@ public class KuduAggregationLimitRule extends RelOptRule {
     return true;
   }
 
-  public Pair<List<RelFieldCollation>, List<String>> getSortPkPrefix(final RelCollation originalCollation,
+  public Pair<List<RelFieldCollation>, List<Integer>> getSortPkPrefix(final RelCollation originalCollation,
       final RelCollation newCollation, final KuduQuery query, final Optional<Filter> filter) {
     boolean isDisableInListOptimizationHintPresent = false;
     final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
     final List<RelFieldCollation> sortPrefixColumns = Lists.newArrayList();
-    final List<String> sortPkColumns = Lists.newArrayList();
-    final Pair<List<RelFieldCollation>, List<String>> pair = new Pair<>(sortPrefixColumns, sortPkColumns);
+    final List<Integer> sortPkColumns = Lists.newArrayList();
+    final Pair<List<RelFieldCollation>, List<Integer>> pair = new Pair<>(sortPrefixColumns, sortPkColumns);
     // If there is no sort just return
     if (newCollation.getFieldCollations().isEmpty()) {
       return pair;
@@ -208,8 +208,7 @@ public class KuduAggregationLimitRule extends RelOptRule {
 
       // use the originalCollations
       sortPrefixColumns.add(originalCollation.getFieldCollations().get(collationIndex));
-      String pkColumnName = openedTable.getSchema().getColumnByIndex(pkColumnIndex).getName();
-      sortPkColumns.add(pkColumnName);
+      sortPkColumns.add(pkColumnIndex);
       pkColumnIndex++;
     }
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
@@ -114,7 +114,7 @@ public class KuduSortedAggregationRule extends KuduSortRule {
     final RelTraitSet traitSet = originalSort.getTraitSet().plus(newCollation).plus(Convention.NONE);
 
     // Check the new trait set to see if we can apply the sort against this.
-    if (!canApply(traitSet, query, query.calciteKuduTable.getKuduTable(), Optional.of(filter))) {
+    if (!canApply(traitSet, originalSort.offset, query, query.calciteKuduTable.getKuduTable(), Optional.of(filter))) {
       return;
     }
 

--- a/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/DescendingSortedOnDatetimeIT.java
@@ -52,7 +52,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public final class DescendingSortedOnDatetimeIT {
-  private static final Logger logger = LoggerFactory.getLogger(JDBCQueryIT.class);
 
   private static String FIRST_SID = "SM1234857";
   private static String SECOND_SID = "SM123485789";

--- a/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/PaginationIT.java
@@ -216,14 +216,13 @@ public class PaginationIT {
   public static Object[] validateRow(ResultSet rs, long expectedTimestamp, String expectedTransactionId,
       String expectedAccountSid) throws SQLException {
     String accountSid = rs.getString(ACCOUNT_SID);
-    String transactionId = rs.getString(3);
+    String transactionId = rs.getString(TRANSACTION_ID);
     long timestamp = rs.getTimestamp(DATE_INITIATED).toInstant().toEpochMilli();
     if (expectedAccountSid != null) {
       assertEquals("Mismatched usage account sid", expectedAccountSid, rs.getString(ACCOUNT_SID));
     }
     assertEquals("Mismatched date initiated", expectedTimestamp + 1, timestamp);
     assertEquals("Mismatched transaction id", expectedTransactionId, transactionId);
-//    System.out.println(rs.getString(ACCOUNT_SID) + " " + rs.getTimestamp(DATE_INITIATED) + " " + rs.getString(TRANSACTION_ID));
     return new Object[] { accountSid, timestamp, transactionId };
   }
 
@@ -274,7 +273,8 @@ public class PaginationIT {
       String sql = String.format(sqlFormat, tableName, ACCOUNT1);
 
       // verify plan
-      String expectedPlanFormat = "KuduToEnumerableRel\n" + "  KuduLimitRel(offset=[5], limit=[20])\n"
+      String expectedPlanFormat = "KuduToEnumerableRel\n"
+          + "  KuduSortRel(offset=[5], fetch=[20], groupBySorted=[false])\n"
           + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
       String expectedPlan = String.format(expectedPlanFormat, ACCOUNT1, tableName);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + sql);
@@ -481,19 +481,19 @@ public class PaginationIT {
       TimestampString lowerBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T1);
       TimestampString upperBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T4);
       String dateInitiatedOrder = descending ? "DESC" : "ASC";
-      String firstBatchSqlFormat = "SELECT * FROM %s %s WHERE (account_sid = '%s' OR account_sid = "
-          + "'%s') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' "
-          + "ORDER BY date_initiated %s, transaction_id " + "LIMIT 7";
+      String firstBatchSqlFormat = "SELECT transaction_id, date_initiated, account_sid FROM %s %s WHERE (account_sid = '%s' OR account_sid = '%s') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' ORDER BY date_initiated %s, transaction_id "
+          + "LIMIT 7";
       String firstBatchSql = String.format(firstBatchSqlFormat, tableName, hint, ACCOUNT1, ACCOUNT2,
           lowerBoundDateInitiated, upperBoundDateInitiated, dateInitiatedOrder);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
 
       String expectedPlanFormat = "KuduToEnumerableRel\n"
-          + "  KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], fetch=[7], " + "groupBySorted=[false])\n"
-          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, "
+          + "  KuduProjectRel(TRANSACTION_ID=[$2], DATE_INITIATED=[$1], ACCOUNT_SID=[$0])\n"
+          + "    KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], fetch=[7], " + "groupBySorted=[false])\n"
+          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, "
           + "date_initiated LESS %d], ScanToken 2=[account_sid EQUAL %s, date_initiated "
-          + "GREATER_EQUAL %d, date_initiated LESS %d])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
+          + "GREATER_EQUAL %d, date_initiated LESS %d])\n" + "        KuduQuery(table=[[kudu, %s]])\n";
       String expectedPlan = String.format(expectedPlanFormat, dateInitiatedOrder, ACCOUNT1, T1 * 1000, T4 * 1000,
           ACCOUNT2, T1 * 1000, T4 * 1000, tableName);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
@@ -530,18 +530,19 @@ public class PaginationIT {
       }
       assertFalse(rs.next());
 
-      String nextBatchSqlFormat = "SELECT * FROM %s %s"
+      String nextBatchSqlFormat = "SELECT transaction_id, date_initiated, account_sid  FROM %s %s"
           + "WHERE ((account_sid = 'ACCOUNT1' AND (date_initiated, transaction_id) > (TIMESTAMP'%s', '%s'))"
           + " OR (account_sid = 'ACCOUNT2' AND (date_initiated, transaction_id) > (TIMESTAMP'%s', '%s'))) "
           + "AND date_initiated >= TIMESTAMP'%s' AND " + "date_initiated < TIMESTAMP'%s' "
           + "ORDER BY date_initiated %s, transaction_id LIMIT 7";
       expectedPlanFormat = "KuduToEnumerableRel\n"
-          + "  KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], fetch=[7], groupBySorted=[false])\n"
-          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL ACCOUNT1, date_initiated %s %d, date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000], "
+          + "  KuduProjectRel(TRANSACTION_ID=[$2], DATE_INITIATED=[$1], ACCOUNT_SID=[$0])\n"
+          + "    KuduSortRel(sort0=[$1], sort1=[$2], dir0=[%s], dir1=[ASC], fetch=[7], groupBySorted=[false])\n"
+          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL ACCOUNT1, date_initiated %s %d, date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000], "
           + "ScanToken 2=[account_sid EQUAL ACCOUNT1, date_initiated EQUAL %d, transaction_id GREATER %s, date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000], "
           + "ScanToken 3=[account_sid EQUAL ACCOUNT2, date_initiated %s %d, date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000], "
           + "ScanToken 4=[account_sid EQUAL ACCOUNT2, date_initiated EQUAL %d, transaction_id GREATER %s, date_initiated GREATER_EQUAL 1000000, date_initiated LESS 4000000])\n"
-          + "      KuduQuery(table=[[kudu, %s]])\n";
+          + "        KuduQuery(table=[[kudu, %s]])\n";
 
       // keep reading batches of rows until we have processes rows for all the
       // partitions
@@ -595,19 +596,20 @@ public class PaginationIT {
       TimestampString lowerBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T1);
       TimestampString upperBoundDateInitiated = TimestampString.fromMillisSinceEpoch(T4);
       String dateInitiatedOrder = descending ? "DESC" : "ASC";
-      String firstBatchSqlFormat = "SELECT * FROM %s %s WHERE (account_sid = 'ACCOUNT1' OR account_sid = 'ACCOUNT2') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' "
-          + "ORDER BY account_sid, date_initiated %s, transaction_id " + "LIMIT 7";
+      String firstBatchSqlFormat = "SELECT transaction_id, date_initiated, account_sid FROM %s %s WHERE (account_sid = 'ACCOUNT1' OR account_sid = 'ACCOUNT2') AND date_initiated >= TIMESTAMP'%s' AND date_initiated < TIMESTAMP'%s' ORDER BY account_sid, date_initiated %s, transaction_id "
+          + "LIMIT 7";
       String firstBatchSql = String.format(firstBatchSqlFormat, tableName, hint, lowerBoundDateInitiated,
           upperBoundDateInitiated, dateInitiatedOrder);
       ResultSet rs = conn.createStatement().executeQuery("EXPLAIN PLAN FOR " + firstBatchSql);
       String plan = SqlUtil.getExplainPlan(rs);
 
       String expectedPlanFormat = "KuduToEnumerableRel\n"
-          + "  KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], dir2=[ASC], "
+          + "  KuduProjectRel(TRANSACTION_ID=[$2], DATE_INITIATED=[$1], ACCOUNT_SID=[$0])\n"
+          + "    KuduSortRel(sort0=[$0], sort1=[$1], sort2=[$2], dir0=[ASC], dir1=[%s], dir2=[ASC], "
           + "fetch=[7], groupBySorted=[false])\n"
-          + "    KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, "
+          + "      KuduFilterRel(ScanToken 1=[account_sid EQUAL %s, date_initiated GREATER_EQUAL %d, "
           + "date_initiated LESS %d], ScanToken 2=[account_sid EQUAL %s, date_initiated "
-          + "GREATER_EQUAL %d, date_initiated LESS %d])\n" + "      KuduQuery(table=[[kudu, %s]])\n";
+          + "GREATER_EQUAL %d, date_initiated LESS %d])\n" + "        KuduQuery(table=[[kudu, %s]])\n";
       String expectedPlan = String.format(expectedPlanFormat, dateInitiatedOrder, ACCOUNT1, T1 * 1000, T4 * 1000,
           ACCOUNT2, T1 * 1000, T4 * 1000, tableName);
       assertEquals(String.format("Unexpected plan\n%s", plan), expectedPlan, plan);
@@ -631,7 +633,7 @@ public class PaginationIT {
       }
       assertFalse(rs.next());
 
-      String nextBatchSqlFormat = "SELECT * FROM %s "
+      String nextBatchSqlFormat = "SELECT transaction_id, date_initiated, account_sid  FROM %s "
           + "WHERE ((account_sid = 'ACCOUNT1' OR account_sid = 'ACCOUNT2') AND (account_sid, "
           + "date_initiated, transaction_id) > ('%s', TIMESTAMP'%s', '%s'))"
           + "AND date_initiated >= TIMESTAMP'%s' AND " + "date_initiated < TIMESTAMP'%s' "

--- a/adapter/src/test/java/com/twilio/kudu/sql/SortedTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/SortedTest.java
@@ -15,6 +15,7 @@
 package com.twilio.kudu.sql;
 
 import com.google.common.collect.Lists;
+import com.twilio.kudu.sql.rel.KuduToEnumerableRel;
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.Schema;
 import org.apache.kudu.Type;
@@ -28,22 +29,13 @@ public final class SortedTest {
 
   @Test
   public void findPrimaryKeyOrder() {
-    final ColumnSchema accountIdColumn = new ColumnSchema.ColumnSchemaBuilder("account_id", Type.INT64).key(true)
-        .build();
-    final ColumnSchema dateColumn = new ColumnSchema.ColumnSchemaBuilder("date", Type.UNIXTIME_MICROS).key(true)
-        .build();
-    final ColumnSchema foreignKey = new ColumnSchema.ColumnSchemaBuilder("key_to_other_table", Type.STRING).build();
-
     assertEquals("Expected to find just account_id from projection", Arrays.asList(1),
-        CalciteKuduTable.getPrimaryKeyColumnsInProjection(Lists.newArrayList("account_id"),
-            new Schema(Arrays.asList(foreignKey, accountIdColumn))));
+        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0), Arrays.asList(10, 0)));
 
     assertEquals("Expected to find account_id and date from projection", Arrays.asList(2, 1),
-        CalciteKuduTable.getPrimaryKeyColumnsInProjection(Lists.newArrayList("account_id", "date"),
-            new Schema(Arrays.asList(foreignKey, dateColumn, accountIdColumn))));
+        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0, 1), Arrays.asList(10, 1, 0)));
 
     assertEquals("Expected to find dateColumn from projection", Arrays.asList(1),
-        CalciteKuduTable.getPrimaryKeyColumnsInProjection(Lists.newArrayList("date"),
-            new Schema(Arrays.asList(foreignKey, dateColumn))));
+        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(1), Arrays.asList(10, 1)));
   }
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Generates the `sortPkColumns` in `KuduToEnumerableRel` and passes it to executeQuery as a List<Integer>.
Also modify the KuduSortRule to get matches if the query has an OFFSET, previously the sort was pushed down but the rule wasn't matched. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
