### PR TITLE
Fix bug in KuduSortedAggregationRule

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortedAggregationRule.java
@@ -93,19 +93,14 @@ public class KuduSortedAggregationRule extends KuduSortRule {
         return;
       }
     }
-    // Take the sorted fields and remap them through the group ordinals and then
-    // through the
-    // project ordinals.
-    // This maps directly to the Kudu field indexes. The Map is between originalSort
-    // ordinal ->
-    // Kudu Field index.
+    // Take the sorted fields and remap them through the project ordinals.
+    // This maps directly to the Kudu field indexes. The Map is between
+    // originalSort ordinal -> Kudu Field index.
     final Map<Integer, Integer> remappingOrdinals = new HashMap<>();
 
-    final List<Integer> groupSet = originalAggregate.getGroupSet().asList();
     for (RelFieldCollation fieldCollation : originalSort.getCollation().getFieldCollations()) {
-      int groupOrdinal = fieldCollation.getFieldIndex();
-      int projectOrdinal = groupSet.get(groupOrdinal);
-      int kuduColumnIndex = ((RexInputRef) project.getProjects().get(projectOrdinal)).getIndex();
+      int ordinal = fieldCollation.getFieldIndex();
+      int kuduColumnIndex = ((RexInputRef) project.getProjects().get(ordinal)).getIndex();
       remappingOrdinals.put(fieldCollation.getFieldIndex(), kuduColumnIndex);
     }
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->
`remappingOrdinals` does not need to be mapped through the group by fields as these refer to the projected columns. 
`testKuduSortedAggregationRuleNotMatched` fails without this fix
```
Caused by: java.lang.RuntimeException: Error while applying rule KuduSortedAggregationRule, args [rel#127:EnumerableLimitSort.ENUMERABLE.[1, 0](input=RelSubset#122,sort0=$1,sort1=$0,dir0=ASC,dir1=ASC,fetch=30), rel#121:EnumerableAggregate.ENUMERABLE.[](input=RelSubset#116,group={0},MY_SUM=SUM($1)), rel#141:KuduToEnumerableRel.ENUMERABLE.[](input=RelSubset#119), rel#159:KuduProjectRel.KUDU.[](input=RelSubset#133,exprs=[$4, $3]), rel#132:KuduFilterRel.KUDU.[](input=RelSubset#84,ScanToken 1=ACCOUNT_SID EQUAL ACCOUNT1), rel#57:KuduQuery.KUDU.[](table=[kudu, SortedAggregationIT])]
	at org.apache.calcite.plan.volcano.VolcanoRuleCall.onMatch(VolcanoRuleCall.java:256)
	at org.apache.calcite.plan.volcano.IterativeRuleDriver.drive(IterativeRuleDriver.java:58)
	at org.apache.calcite.plan.volcano.VolcanoPlanner.findBestExp(VolcanoPlanner.java:510)
	at org.apache.calcite.tools.Programs.lambda$standard$3(Programs.java:271)
	at org.apache.calcite.tools.Programs$SequenceProgram.run(Programs.java:331)
	at org.apache.calcite.prepare.Prepare.optimize(Prepare.java:166)
	at org.apache.calcite.prepare.Prepare.prepareSql(Prepare.java:291)
	at org.apache.calcite.prepare.Prepare.prepareSql(Prepare.java:208)
	at org.apache.calcite.prepare.CalcitePrepareImpl.prepare2_(CalcitePrepareImpl.java:642)
	at org.apache.calcite.prepare.CalcitePrepareImpl.prepare_(CalcitePrepareImpl.java:508)
	at org.apache.calcite.prepare.CalcitePrepareImpl.prepareSql(CalcitePrepareImpl.java:478)
	at org.apache.calcite.jdbc.CalciteConnectionImpl.parseQuery(CalciteConnectionImpl.java:231)
	at org.apache.calcite.jdbc.CalciteMetaImpl.prepareAndExecute(CalciteMetaImpl.java:556)
	at org.apache.calcite.avatica.AvaticaConnection.prepareAndExecuteInternal(AvaticaConnection.java:675)
	at org.apache.calcite.avatica.AvaticaStatement.executeInternal(AvaticaStatement.java:156)
	... 33 more
Caused by: java.lang.IndexOutOfBoundsException: index out of range: 0
	at org.apache.calcite.util.ImmutableBitSet.nth(ImmutableBitSet.java:843)
	at org.apache.calcite.util.ImmutableBitSet$2.get(ImmutableBitSet.java:622)
	at org.apache.calcite.util.ImmutableBitSet$2.get(ImmutableBitSet.java:620)
	at com.twilio.kudu.sql.rules.KuduSortedAggregationRule.perform(KuduSortedAggregationRule.java:107)
	at com.twilio.kudu.sql.rules.KuduSortedAggregationRule.onMatch(KuduSortedAggregationRule.java:149)
	at org.apache.calcite.plan.volcano.VolcanoRuleCall.onMatch(VolcanoRuleCall.java:229)
	... 47 more


```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
