### PR TITLE
Update jackson to address deeply nested stack overflow attack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <mockito.version>3.7.7</mockito.version>
-        <jackson.version>2.11.1</jackson.version>
+        <jackson.version>2.13.2.20220328</jackson.version>
         <spotless.version>2.0.1</spotless.version>
         <freemarker-version>2.3.30</freemarker-version>
         <json-version>20200518</json-version>
@@ -174,12 +174,6 @@
                 <version>${guava.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-
             <!-- Testing dependencies -->
             <dependency>
                 <groupId>junit</groupId>
@@ -245,21 +239,14 @@
             </dependency>
 
             <!-- https://ossindex.sonatype.org/vulnerability/f582b4ea-ef28-4d6e-93ad-15034025df21 -->
-            <dependency>
-              <groupId>com.fasterxml.jackson.core</groupId>
-              <artifactId>jackson-core</artifactId>
-              <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.fasterxml.jackson.core</groupId>
-              <artifactId>jackson-databind</artifactId>
-              <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.fasterxml.jackson.dataformat</groupId>
-              <artifactId>jackson-dataformat-yaml</artifactId>
-              <version>${jackson.version}</version>
-            </dependency>
+			<!-- https://github.com/advisories/GHSA-57j2-w4cx-62h2 -->
+			<dependency>
+			  <groupId>com.fasterxml.jackson</groupId>
+			  <artifactId>jackson-bom</artifactId>
+			  <version>${jackson.version}</version>
+			  <type>pom</type>
+			  <scope>import</scope>
+			</dependency>
         </dependencies>
     </dependencyManagement>
     <build>


### PR DESCRIPTION
## Why:
This got flagged by depend bot:
https://github.com/advisories/GHSA-57j2-w4cx-62h2

## How:
This removes the previous code that pulls in specific artifacts and
uses the Jackson bill of materials project:
https://github.com/FasterXML/jackson-bom

The `<scope>import</scope>` then imports the various jackson
artifacts with the proper versions

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
