### PR TITLE
Revert from Integer to String sortPKColumns

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduRelNode.java
@@ -79,7 +79,7 @@ public interface KuduRelNode extends RelNode {
     // if groupByLimited is true and sortPkPrefixColumns is empty
     // that means we are sorting by the same columns as we are grouping by
     public List<RelFieldCollation> sortPkPrefixColumns = new ArrayList<>();
-    public List<Integer> sortPkColumns = new ArrayList<>();
+    public List<String> sortPkColumns = new ArrayList<>();
 
     // information required for executing an update
     public List<Integer> columnIndexes;

--- a/adapter/src/main/java/com/twilio/kudu/sql/ScannerCallback.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/ScannerCallback.java
@@ -14,6 +14,7 @@
  */
 package com.twilio.kudu.sql;
 
+import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import com.stumbleupon.async.Callback;
 import org.apache.kudu.client.RowResultIterator;
@@ -62,7 +63,7 @@ final public class ScannerCallback implements Callback<Deferred<Void>, RowResult
       final BlockingQueue<CalciteScannerMessage<CalciteRow>> rowResults, final AtomicBoolean scansShouldStop,
       final AtomicBoolean cancelFlag, final Schema projectedSchema, final KuduScanStats scanStats,
       final boolean isScannerSorted, final Function1<Object, Object> projectionMapper,
-      final Predicate1<Object> filterFunction, final boolean isSingleObject, final List<Integer> sortPkColumns) {
+      final Predicate1<Object> filterFunction, final boolean isSingleObject, final List<String> sortPkColumnNames) {
 
     this.scanner = scanner;
     this.rowResults = rowResults;
@@ -70,7 +71,9 @@ final public class ScannerCallback implements Callback<Deferred<Void>, RowResult
     // if the scanner is sorted, KuduEnumerable has to merge the results from
     // multiple
     // scanners (by picking the smallest row order by primary key key columns)
-    this.sortPkColumns = sortPkColumns;
+    this.sortPkColumns = isScannerSorted
+        ? calciteKuduTable.getPrimaryKeyColumnsInProjection(sortPkColumnNames, projectedSchema)
+        : Collections.emptyList();
     this.descendingSortedFieldIndices = calciteKuduTable.getDescendingColumnsIndicesInProjection(projectedSchema);
     this.scanStats = scanStats;
     // @NOTE: this can be NULL. Need to check it.

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduSortRel.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduSortRel.java
@@ -51,27 +51,28 @@ public class KuduSortRel extends Sort implements KuduRelNode {
   // and
   // sortPrefixColumns is empty.
   public final List<RelFieldCollation> sortPkPrefixColumns;
-  public final List<Integer> sortPkColumns;
+  public final List<String> sortPkColumnNames;
 
   public KuduSortRel(RelOptCluster cluster, RelTraitSet traitSet, RelNode child, RelCollation collation, RexNode offset,
-      RexNode fetch, List<Integer> sortPkColumns) {
-    this(cluster, traitSet, child, collation, offset, fetch, false, Lists.newArrayList(), sortPkColumns);
+      RexNode fetch, List<String> sortPkColumnNames) {
+    this(cluster, traitSet, child, collation, offset, fetch, false, Lists.newArrayList(), sortPkColumnNames);
   }
 
   public KuduSortRel(RelOptCluster cluster, RelTraitSet traitSet, RelNode child, RelCollation collation, RexNode offset,
-      RexNode fetch, boolean groupBySorted, List<RelFieldCollation> sortPkPrefixColumns, List<Integer> sortPkColumns) {
+      RexNode fetch, boolean groupBySorted, List<RelFieldCollation> sortPkPrefixColumns,
+      List<String> sortPkColumnNames) {
     super(cluster, traitSet, child, collation, offset, fetch);
     assert getConvention() == KuduRelNode.CONVENTION;
     assert getConvention() == child.getConvention();
     this.groupBySorted = groupBySorted;
     this.sortPkPrefixColumns = sortPkPrefixColumns;
-    this.sortPkColumns = sortPkColumns;
+    this.sortPkColumnNames = sortPkColumnNames;
   }
 
   @Override
   public Sort copy(RelTraitSet traitSet, RelNode input, RelCollation newCollation, RexNode offset, RexNode fetch) {
     return new KuduSortRel(getCluster(), traitSet, input, collation, offset, fetch, groupBySorted, sortPkPrefixColumns,
-        sortPkColumns);
+        sortPkColumnNames);
   }
 
   @Override
@@ -112,6 +113,6 @@ public class KuduSortRel extends Sort implements KuduRelNode {
 
     implementor.groupByLimited = groupBySorted;
     implementor.sortPkPrefixColumns.addAll(sortPkPrefixColumns);
-    implementor.sortPkColumns.addAll(sortPkColumns);
+    implementor.sortPkColumns.addAll(sortPkColumnNames);
   }
 }

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduToEnumerableRel.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduToEnumerableRel.java
@@ -227,8 +227,8 @@ public class KuduToEnumerableRel extends ConverterImpl implements EnumerableRel 
     }
     Expressions.list(list.append("keySelector", sortedPrefixKeySelector));
 
-    final Expression sortPkColumns = list.append("sortPkColumns", implementor
-        .stash(getPrimaryKeyColumnsInProjection(kuduImplementor.sortPkColumns, kuduColumnIndices), List.class));
+    final Expression sortPkColumns = list.append("sortPkColumns",
+        implementor.stash(kuduImplementor.sortPkColumns, List.class));
 
     final Expression enumerable = list.append("enumerable",
         Expressions.call(table, KuduMethod.KUDU_QUERY_METHOD.method, predicates, fields, limit, offset, sorted,
@@ -240,61 +240,6 @@ public class KuduToEnumerableRel extends ConverterImpl implements EnumerableRel 
 
     KuduToEnumerableConverter.logger.debug("Created a KuduQueryable " + list.toBlock());
     return implementor.result(physType, list.toBlock());
-  }
-
-  /**
-   * Return the Integer indices in the Row Projection that match the primary key
-   * columns and in the order they need to match. This lays out how to compare two
-   * {@code CalciteRow}s and determine which one is smaller.
-   * <p>
-   * As an example, imagine we have a table (A, B, C, D, E) with primary columns
-   * in order of (A, B) and we have a scanner SELECT D, C, E, B, A the
-   * projectedSchema will be D, C, E, B, A and the tableSchema will be A, B, C, D,
-   * E *this* function will return List(4, 3) -- the position's of A and B within
-   * the projection and in the order they need to be sorted by.
-   * <p>
-   * The returned index list is used by the sorted {@link KuduEnumerable} to merge
-   * the results from multiple scanners.
-   *
-   * @param projectedColumnIndices the indices of the columns that are being
-   *                               selected or required to evaluate a filter in
-   *                               memory
-   *
-   * @param sortPkColumnIndices    the indices of the primary key columns that are
-   *                               present in the ORDER BY clause
-   *
-   * @return List of column indexes that part of the primary key in the Kudu
-   *         Sorted order
-   */
-  @VisibleForTesting
-  public static List<Integer> getPrimaryKeyColumnsInProjection(final List<Integer> sortPkColumnIndices,
-      final List<Integer> projectedColumnIndices) {
-    final List<Integer> primaryKeyColumnsInProjection = new ArrayList<>();
-    // KuduSortRule checks if the prefix of the primary key columns are being
-    // filtered and are
-    // set to a constant literal, or if the columns being sorted are a prefix of the
-    // primary key
-    // columns.
-    for (int sortPkColumnIndex : sortPkColumnIndices) {
-      boolean found = false;
-      for (int i = 0; i < projectedColumnIndices.size(); ++i) {
-        int projectedColumnIndex = projectedColumnIndices.get(i);
-        if (sortPkColumnIndex == projectedColumnIndex) {
-          primaryKeyColumnsInProjection.add(i);
-          found = true;
-        }
-      }
-      if (!found) {
-        String projectedColumnIndicesString = projectedColumnIndices.stream().map(Object::toString)
-            .collect(Collectors.joining(", "));
-        String sortPkColumnIndicesString = sortPkColumnIndices.stream().map(Object::toString)
-            .collect(Collectors.joining(", "));
-        throw new IllegalStateException("Unable to find primary key column index " + sortPkColumnIndex
-            + " in the projection, " + "projectedColumnIndices " + projectedColumnIndicesString
-            + " sortPkColumnIndices " + sortPkColumnIndicesString);
-      }
-    }
-    return primaryKeyColumnsInProjection;
   }
 
   private Result executeMutation(EnumerableRelImplementor implementor, Prefer prefer) {

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduAggregationLimitRule.java
@@ -127,7 +127,7 @@ public class KuduAggregationLimitRule extends RelOptRule {
     }
 
     // Check the new trait set to see if we can apply the sort against this.
-    final Pair<List<RelFieldCollation>, List<Integer>> pair = getSortPkPrefix(originalSort.getCollation(), newCollation,
+    final Pair<List<RelFieldCollation>, List<String>> pair = getSortPkPrefix(originalSort.getCollation(), newCollation,
         query, Optional.of(filter));
     if (pair.left.isEmpty()) {
       return;
@@ -165,13 +165,13 @@ public class KuduAggregationLimitRule extends RelOptRule {
     return true;
   }
 
-  public Pair<List<RelFieldCollation>, List<Integer>> getSortPkPrefix(final RelCollation originalCollation,
+  public Pair<List<RelFieldCollation>, List<String>> getSortPkPrefix(final RelCollation originalCollation,
       final RelCollation newCollation, final KuduQuery query, final Optional<Filter> filter) {
     boolean isDisableInListOptimizationHintPresent = false;
     final KuduTable openedTable = query.calciteKuduTable.getKuduTable();
     final List<RelFieldCollation> sortPrefixColumns = Lists.newArrayList();
-    final List<Integer> sortPkColumns = Lists.newArrayList();
-    final Pair<List<RelFieldCollation>, List<Integer>> pair = new Pair<>(sortPrefixColumns, sortPkColumns);
+    final List<String> sortPkColumns = Lists.newArrayList();
+    final Pair<List<RelFieldCollation>, List<String>> pair = new Pair<>(sortPrefixColumns, sortPkColumns);
     // If there is no sort just return
     if (newCollation.getFieldCollations().isEmpty()) {
       return pair;
@@ -208,7 +208,8 @@ public class KuduAggregationLimitRule extends RelOptRule {
 
       // use the originalCollations
       sortPrefixColumns.add(originalCollation.getFieldCollations().get(collationIndex));
-      sortPkColumns.add(pkColumnIndex);
+      String pkColumnName = openedTable.getSchema().getColumnByIndex(pkColumnIndex).getName();
+      sortPkColumns.add(pkColumnName);
       pkColumnIndex++;
     }
 

--- a/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rules/KuduSortRule.java
@@ -62,7 +62,7 @@ public abstract class KuduSortRule extends RelOptRule {
   public static final RelOptRule SIMPLE_SORT_RULE = new KuduSortWithoutFilter(RelFactories.LOGICAL_BUILDER);
   public static final RelOptRule FILTER_SORT_RULE = new KuduSortWithFilter(RelFactories.LOGICAL_BUILDER);
 
-  protected List<Integer> pkSortColumns = Lists.newArrayList();
+  protected List<String> pkSortColumns = Lists.newArrayList();
 
   public KuduSortRule(RelOptRuleOperand operand, RelBuilderFactory factory, String description) {
     super(operand, factory, description);
@@ -83,7 +83,7 @@ public abstract class KuduSortRule extends RelOptRule {
         // if we have an OFFSET return rows sorted by the primary key even if there
         // isn't an
         // ORDER BY clause so rows are returned in a deterministic order
-        pkSortColumns = IntStream.range(0, openedTable.getSchema().getPrimaryKeyColumnCount()).boxed()
+        pkSortColumns = openedTable.getSchema().getPrimaryKeyColumns().stream().map(schema -> schema.getName())
             .collect(Collectors.toList());
         return true;
       } else {
@@ -131,7 +131,8 @@ public abstract class KuduSortRule extends RelOptRule {
           return false;
         }
       }
-      pkSortColumns.add(pkColumnIndex);
+      String pkColumnName = openedTable.getSchema().getColumnByIndex(pkColumnIndex).getName();
+      pkSortColumns.add(pkColumnName);
       pkColumnIndex++;
     }
     return true;

--- a/adapter/src/test/java/com/twilio/kudu/sql/SortedTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/SortedTest.java
@@ -26,16 +26,24 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 
 public final class SortedTest {
-
   @Test
   public void findPrimaryKeyOrder() {
+    final ColumnSchema accountIdColumn = new ColumnSchema.ColumnSchemaBuilder("account_id", Type.INT64).key(true)
+        .build();
+    final ColumnSchema dateColumn = new ColumnSchema.ColumnSchemaBuilder("date", Type.UNIXTIME_MICROS).key(true)
+        .build();
+    final ColumnSchema foreignKey = new ColumnSchema.ColumnSchemaBuilder("key_to_other_table", Type.STRING).build();
+
     assertEquals("Expected to find just account_id from projection", Arrays.asList(1),
-        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0), Arrays.asList(10, 0)));
+        CalciteKuduTable.getPrimaryKeyColumnsInProjection(Lists.newArrayList("account_id"),
+            new Schema(Arrays.asList(foreignKey, accountIdColumn))));
 
     assertEquals("Expected to find account_id and date from projection", Arrays.asList(2, 1),
-        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0, 1), Arrays.asList(10, 1, 0)));
+        CalciteKuduTable.getPrimaryKeyColumnsInProjection(Lists.newArrayList("account_id", "date"),
+            new Schema(Arrays.asList(foreignKey, dateColumn, accountIdColumn))));
 
     assertEquals("Expected to find dateColumn from projection", Arrays.asList(1),
-        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(1), Arrays.asList(10, 1)));
+        CalciteKuduTable.getPrimaryKeyColumnsInProjection(Lists.newArrayList("date"),
+            new Schema(Arrays.asList(foreignKey, dateColumn))));
   }
 }


### PR DESCRIPTION
Selective revert of https://github.com/twilio/calcite-kudu/pull/68/files to use String instead of Integer.
See intermittent failures with stashing Integer variables - 
```bash
Suppressed: java.lang.IllegalStateException: Unable to find primary key column index 1 in the projection, projectedColumnIndices 2, 5, 6 sortPkColumnIndices 1
		at com.twilio.kudu.sql.rel.KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(KuduToEnumerableRel.java:292)
		at com.twilio.kudu.sql.rel.KuduToEnumerableRel.executeQuery(KuduToEnumerableRel.java:231)
		at com.twilio.kudu.sql.rel.KuduToEnumerableRel.implement(KuduToEnumerableRel.java:89)
		at org.apache.calcite.adapter.enumerable.EnumerableRelImplementor.implementRoot(EnumerableRelImplementor.java:108)
		... 6 more 
```

Likely the Java Integer pool persists the List across queries for a short amount of time, causing this leak - https://javadoc.io/static/org.apache.calcite/calcite-core/1.22.0/org/apache/calcite/adapter/enumerable/EnumerableRelImplementor.html#stash-T-java.lang.Class-

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ Y ] I acknowledge that all my contributions will be made under the project's license.
