### PR TITLE
Remove static references

### DIFF
--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -80,6 +80,11 @@
           <artifactId>mockito-core</artifactId>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-inline</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduToEnumerableRel.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/rel/KuduToEnumerableRel.java
@@ -14,7 +14,6 @@
  */
 package com.twilio.kudu.sql.rel;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.twilio.kudu.sql.KuduEnumerable;
 import com.twilio.kudu.sql.KuduMethod;
 import com.twilio.kudu.sql.KuduPhysType;
@@ -266,8 +265,7 @@ public class KuduToEnumerableRel extends ConverterImpl implements EnumerableRel 
    * @return List of column indexes that part of the primary key in the Kudu
    *         Sorted order
    */
-  @VisibleForTesting
-  public static List<Integer> getPrimaryKeyColumnsInProjection(final List<Integer> sortPkColumnIndices,
+  public List<Integer> getPrimaryKeyColumnsInProjection(final List<Integer> sortPkColumnIndices,
       final List<Integer> projectedColumnIndices) {
     final List<Integer> primaryKeyColumnsInProjection = new ArrayList<>();
     // KuduSortRule checks if the prefix of the primary key columns are being

--- a/adapter/src/test/java/com/twilio/kudu/sql/SortedTest.java
+++ b/adapter/src/test/java/com/twilio/kudu/sql/SortedTest.java
@@ -16,26 +16,29 @@ package com.twilio.kudu.sql;
 
 import com.google.common.collect.Lists;
 import com.twilio.kudu.sql.rel.KuduToEnumerableRel;
-import org.apache.kudu.ColumnSchema;
-import org.apache.kudu.Schema;
-import org.apache.kudu.Type;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
 import org.junit.Test;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public final class SortedTest {
 
   @Test
   public void findPrimaryKeyOrder() {
+    final KuduToEnumerableRel kuduToEnumerableRel = new KuduToEnumerableRel(mock(RelOptCluster.class),
+        mock(RelTraitSet.class), mock(RelNode.class));
     assertEquals("Expected to find just account_id from projection", Arrays.asList(1),
-        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0), Arrays.asList(10, 0)));
+        kuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0), Arrays.asList(10, 0)));
 
     assertEquals("Expected to find account_id and date from projection", Arrays.asList(2, 1),
-        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0, 1), Arrays.asList(10, 1, 0)));
+        kuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(0, 1), Arrays.asList(10, 1, 0)));
 
     assertEquals("Expected to find dateColumn from projection", Arrays.asList(1),
-        KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(1), Arrays.asList(10, 1)));
+        kuduToEnumerableRel.getPrimaryKeyColumnsInProjection(Lists.newArrayList(1), Arrays.asList(10, 1)));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
-        <mockito.version>3.7.7</mockito.version>
+        <mockito.version>4.6.1</mockito.version>
         <jackson.version>2.13.2.20220328</jackson.version>
         <spotless.version>2.0.1</spotless.version>
         <freemarker-version>2.3.30</freemarker-version>
@@ -208,10 +208,16 @@
               <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <scope>test</scope>
-                <version>${mockito.version}</version>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-core</artifactId>
+              <version>${mockito.version}</version>
+              <scope>test</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-inline</artifactId>
+              <version>${mockito.version}</version>
+              <scope>test</scope>
             </dependency>
             <dependency>
                 <artifactId>freemarker</artifactId>


### PR DESCRIPTION
Fix for intermittent failures of not finding sort Indexes in current thread/query's list suggesting a leak - 
```bash
Suppressed: java.lang.IllegalStateException: Unable to find primary key column index 1 in the projection, projectedColumnIndices 2, 5, 6 sortPkColumnIndices 1
		at com.twilio.kudu.sql.rel.KuduToEnumerableRel.getPrimaryKeyColumnsInProjection(KuduToEnumerableRel.java:292)
		at com.twilio.kudu.sql.rel.KuduToEnumerableRel.executeQuery(KuduToEnumerableRel.java:231)
		at com.twilio.kudu.sql.rel.KuduToEnumerableRel.implement(KuduToEnumerableRel.java:89)
		at org.apache.calcite.adapter.enumerable.EnumerableRelImplementor.implementRoot(EnumerableRelImplementor.java:108)
		... 6 more 
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
