### PR TITLE
Remove the new Semi Join Rule because it drops Project aliases

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -109,6 +109,10 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
     // KuduFilterIntoJoinRule which expands SArgs
     planner.removeRule(CoreRules.FILTER_INTO_JOIN);
 
+    // This rule is broken and drops named projections. Remove until fixed:
+    // CALCITE-5391
+    planner.removeRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN);
+
     planner.addRule(EnumerableRules.ENUMERABLE_LIMIT_SORT_RULE);
 
     KuduRules.CORE_RULES.stream().forEach(rule -> planner.addRule(rule));


### PR DESCRIPTION
## Why:
As noted here https://github.com/apache/calcite/pull/2975, the rule doesn't pass the field aliases into the new project it creates. This breaks the result set.

## How:
By removing the rule from the planner when the `KuduQuery` is registered with the planner and cluster

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
