### PR TITLE
Re-enable Unique Semi Join rule

### DIFF
--- a/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
+++ b/adapter/src/main/java/com/twilio/kudu/sql/KuduQuery.java
@@ -109,10 +109,6 @@ public final class KuduQuery extends TableScan implements KuduRelNode {
     // KuduFilterIntoJoinRule which expands SArgs
     planner.removeRule(CoreRules.FILTER_INTO_JOIN);
 
-    // This rule is broken and drops named projections. Remove until fixed:
-    // CALCITE-5391
-    planner.removeRule(CoreRules.JOIN_ON_UNIQUE_TO_SEMI_JOIN);
-
     planner.addRule(EnumerableRules.ENUMERABLE_LIMIT_SORT_RULE);
 
     KuduRules.CORE_RULES.stream().forEach(rule -> planner.addRule(rule));


### PR DESCRIPTION
## Why:
After working on CALCITE-5391, I came to the conclusion the rule is not actually broken -- not strictly -- and Twilio's own application is actually not using Calcite correctly. As discovered by Drill and Twilio, Calcite's planner will accept a new `RelNode` from a rule that matches the shape of the original *but doesn't have the same names*. This allows for different optimizations within the planner.

To use Calcite correctly, the applications need to keep the original validated type from before the physical planning. This can be seen in how the JDBC uses RelRoot.

## How:
Removes the removed rule

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
