### PR TITLE
Calcite 1.34 and Commons Codec 1.15

### DIFF
--- a/adapter/src/main/codegen/config.fmpp
+++ b/adapter/src/main/codegen/config.fmpp
@@ -440,6 +440,8 @@ data: {
     includeCompoundIdentifier: true
     includeBraces: true
     includeAdditionalDeclarations: false
+    # https://issues.apache.org/jira/browse/CALCITE-5159 introduced this
+    includeParsingStringLiteralAsArrayLiteral: false
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <kudu.version>1.16.0</kudu.version>
         <!-- If https://issues.apache.org/jira/browse/CALCITE-5226 is resolved
              remove the commons-dpcp2 in dependency management -->
-        <calcite.version>1.32.0</calcite.version>
+        <calcite.version>1.34.0</calcite.version>
         <guava.version>30.1.1-jre</guava.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.14</version>
+                <version>1.15</version>
             </dependency>
 
             <dependency>
@@ -141,21 +141,7 @@
                 <artifactId>calcite-core</artifactId>
                 <version>${calcite.version}</version>
             </dependency>
-            <!-- This is a dependency of calcite-core that pulls in log4j1.x
-                 This is just copy and pasta from over 8 years ago and at that time log4j
-                 was assumed for runtime dependency.
-                 It is *NOT* used during compliation or runtime by this library -->
-            <dependency>
-              <groupId>com.google.uzaygezen</groupId>
-              <artifactId>uzaygezen-core</artifactId>
-              <version>0.2</version>
-              <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-              </exclusions>
-            </dependency>
+
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
## Why:
To keep pace with changes and improvements with within Calcite.

## How:
[Calcite fixes the log4j1 that was being pulled in by uzaygezen-core](https://issues.apache.org/jira/browse/CALCITE-4858). The commons codec has a bunch of improvements as well.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
