### PR TITLE
Build on JDK17

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Update to release version
         run: mvn -B build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion} -DgenerateBackupPoms=false

--- a/.github/workflows/run-code-format.yml
+++ b/.github/workflows/run-code-format.yml
@@ -28,9 +28,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Verify Code Format
       run: mvn -q spotless:check

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,9 +28,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Execute all tests
       run: mvn -B verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 dist: xenial
 os: linux
 jdk:
-- openjdk11
+- openjdk17
 cache:
   directories:
   - "$HOME/.m2/repository/"

--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -95,6 +95,7 @@
                     <!-- the generated source for com.twilio.kudu.sql.parser.ParseException
                          generates unparse-able documentation -->
                     <excludePackageNames>com.twilio.kudu.sql.parser</excludePackageNames>
+                    <doclint>all,-missing</doclint>
 
                     <!-- whats the point of generating javadoc if not everything is documented properly -->
                     <failOnWarnings>true</failOnWarnings>

--- a/adapter/src/main/java/org/apache/calcite/prepare/KuduPrepareImpl.java
+++ b/adapter/src/main/java/org/apache/calcite/prepare/KuduPrepareImpl.java
@@ -421,16 +421,16 @@ public class KuduPrepareImpl extends CalcitePrepareImpl {
               if (operator.getName().equalsIgnoreCase("COUNT")) {
                 ColumnSchema.ColumnSchemaBuilder columnSchemaBuilder = new ColumnSchema.ColumnSchemaBuilder(columnName,
                     org.apache.kudu.Type.INT64).key(false) // all columns should be non-nullable
-                        .nullable(false).wireType(Common.DataType.INT64);
+                    .nullable(false).wireType(Common.DataType.INT64);
                 cubeColumnSchemas.add(columnSchemaBuilder.build());
               } else {
                 // use originalColumnName to get the column schema
                 ColumnSchema colSchema = kuduTable.getSchema().getColumn(factColumnName);
                 ColumnSchema.ColumnSchemaBuilder columnSchemaBuilder = new ColumnSchema.ColumnSchemaBuilder(columnName,
                     colSchema.getType()).key(false) // all columns should be non-nullable
-                        .nullable(false).desiredBlockSize(colSchema.getDesiredBlockSize())
-                        .encoding(colSchema.getEncoding()).compressionAlgorithm(colSchema.getCompressionAlgorithm())
-                        .typeAttributes(colSchema.getTypeAttributes()).wireType(colSchema.getWireType());
+                    .nullable(false).desiredBlockSize(colSchema.getDesiredBlockSize()).encoding(colSchema.getEncoding())
+                    .compressionAlgorithm(colSchema.getCompressionAlgorithm())
+                    .typeAttributes(colSchema.getTypeAttributes()).wireType(colSchema.getWireType());
                 cubeColumnSchemas.add(columnSchemaBuilder.build());
               }
             }

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM alpine:3.12
+FROM alpine:3.18
 WORKDIR /app
 COPY target/kudu-client.jar /app
-RUN apk add --no-cache openjdk11
+RUN apk add --no-cache openjdk17
 ENTRYPOINT tail -f /dev/null

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <mockito.version>4.6.1</mockito.version>
         <spotless.version>2.41.1</spotless.version>
         <freemarker-version>2.3.30</freemarker-version>
-        <json-version>20200518</json-version>
+        <json-version>20231013</json-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,14 @@
         <kudu.version>1.16.0</kudu.version>
         <!-- If https://issues.apache.org/jira/browse/CALCITE-5226 is resolved
              remove the commons-dpcp2 in dependency management -->
-        <calcite.version>1.36.0</calcite.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <junit.version>4.13.1</junit.version>
+        <calcite.version>1.34.0</calcite.version>
+        <guava.version>32.1.3-jre</guava.version>
+        <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <mockito.version>4.6.1</mockito.version>
-        <spotless.version>2.0.1</spotless.version>
-        <freemarker-version>2.3.32</freemarker-version>
+        <spotless.version>2.41.1</spotless.version>
+        <freemarker-version>2.3.30</freemarker-version>
         <json-version>20200518</json-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -211,7 +211,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-dbcp2</artifactId>
-                <version>2.9.0</version>
+                <version>2.11.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -230,12 +230,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <target>${java.version}</target>
                     <source>${java.version}</source>
@@ -261,7 +261,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.6.3</version>
                 <configuration>
                     <source>${jdk.version}</source>
                 </configuration>
@@ -277,7 +277,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -338,9 +338,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.2.2</version>
                 <configuration>
                   <skipTests>false</skipTests>
+                  <argLine>
+                      --add-opens=java.base/java.net=ALL-UNNAMED
+                      --add-opens=java.base/java.lang=ALL-UNNAMED
+                      --add-opens=java.base/java.util=ALL-UNNAMED
+                  </argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -362,7 +367,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.2.2</version>
                 <configuration>
                   <skipTests>${skipTests}</skipTests>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <kudu.version>1.16.0</kudu.version>
         <!-- If https://issues.apache.org/jira/browse/CALCITE-5226 is resolved
              remove the commons-dpcp2 in dependency management -->
-        <calcite.version>1.34.0</calcite.version>
+        <calcite.version>1.36.0</calcite.version>
         <guava.version>32.1.3-jre</guava.version>
         <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.21</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,20 +57,20 @@
         <kudu.version>1.16.0</kudu.version>
         <!-- If https://issues.apache.org/jira/browse/CALCITE-5226 is resolved
              remove the commons-dpcp2 in dependency management -->
-        <calcite.version>1.34.0</calcite.version>
+        <calcite.version>1.36.0</calcite.version>
         <guava.version>30.1.1-jre</guava.version>
         <junit.version>4.13.1</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <mockito.version>4.6.1</mockito.version>
         <spotless.version>2.0.1</spotless.version>
-        <freemarker-version>2.3.30</freemarker-version>
+        <freemarker-version>2.3.32</freemarker-version>
         <json-version>20200518</json-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
-        <jdk.version>8</jdk.version>
+        <java.version>17</java.version>
+        <jdk.version>17</jdk.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <kudu.version>1.16.0</kudu.version>
         <!-- If https://issues.apache.org/jira/browse/CALCITE-5226 is resolved
              remove the commons-dpcp2 in dependency management -->
-        <calcite.version>1.36.0</calcite.version>
+        <calcite.version>1.34.0</calcite.version>
         <guava.version>32.1.3-jre</guava.version>
         <junit.version>4.13.2</junit.version>
         <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
Move from using JDK8 to JDK17, because at the moment projects that have `calcite-kudu` as a dependency fail to build on JDK17.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
